### PR TITLE
Update to more recent iced commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ members = [
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-iced = { git = "https://github.com/iced-rs/iced", rev = "26d053a", features=["canvas"] }
+iced = { git = "https://github.com/iced-rs/iced", rev = "a53fa91e0ddf374bbeb66d5e831b79127ed47a9d", features=["canvas"] }
 
 [dependencies]
-iced_native = { git = "https://github.com/iced-rs/iced", rev = "26d053a" }
-iced_graphics = { git = "https://github.com/iced-rs/iced", rev = "26d053a", features=["canvas"] }
+iced_native = { git = "https://github.com/iced-rs/iced", rev = "a53fa91e0ddf374bbeb66d5e831b79127ed47a9d" }
+iced_graphics = { git = "https://github.com/iced-rs/iced", rev = "a53fa91e0ddf374bbeb66d5e831b79127ed47a9d", features=["canvas"] }

--- a/examples/inputs_tour/Cargo.toml
+++ b/examples/inputs_tour/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { git = "https://github.com/iced-rs/iced", rev = "26d053a", features=["image"] }
+iced = { git = "https://github.com/iced-rs/iced", rev = "a53fa91e0ddf374bbeb66d5e831b79127ed47a9d", features=["image"] }
 iced_audio = { path = "../../" }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { git = "https://github.com/iced-rs/iced", rev = "26d053a" }
+iced = { git = "https://github.com/iced-rs/iced", rev = "a53fa91e0ddf374bbeb66d5e831b79127ed47a9d" }
 iced_audio = { path = "../../" }

--- a/src/native/h_slider.rs
+++ b/src/native/h_slider.rs
@@ -5,11 +5,9 @@
 use std::fmt::Debug;
 
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Hasher, Layout,
-    Length, Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
+    Point, Rectangle, Shell, Size, Widget,
 };
-
-use std::hash::Hash;
 
 use crate::native::{text_marks, tick_marks};
 use crate::{
@@ -475,14 +473,6 @@ where
             &self.state.tick_marks_cache,
             &self.state.text_marks_cache,
         )
-    }
-
-    fn hash_layout(&self, state: &mut Hasher) {
-        struct Marker;
-        std::any::TypeId::of::<Marker>().hash(state);
-
-        self.width.hash(state);
-        self.height.hash(state);
     }
 }
 

--- a/src/native/knob.rs
+++ b/src/native/knob.rs
@@ -5,11 +5,9 @@
 use std::fmt::Debug;
 
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Hasher, Layout,
-    Length, Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
+    Point, Rectangle, Shell, Size, Widget,
 };
-
-use std::hash::Hash;
 
 use crate::core::{ModulationRange, Normal, NormalParam};
 use crate::native::{text_marks, tick_marks};
@@ -475,13 +473,6 @@ where
             &self.state.tick_marks_cache,
             &self.state.text_marks_cache,
         )
-    }
-
-    fn hash_layout(&self, state: &mut Hasher) {
-        struct Marker;
-        std::any::TypeId::of::<Marker>().hash(state);
-
-        self.size.hash(state);
     }
 }
 

--- a/src/native/mod_range_input.rs
+++ b/src/native/mod_range_input.rs
@@ -5,11 +5,9 @@
 use std::fmt::Debug;
 
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Hasher, Layout,
-    Length, Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
+    Point, Rectangle, Shell, Size, Widget,
 };
-
-use std::hash::Hash;
 
 use crate::core::{Normal, NormalParam};
 use crate::IntRange;
@@ -393,13 +391,6 @@ where
             self.state.is_dragging,
             &self.style,
         )
-    }
-
-    fn hash_layout(&self, state: &mut Hasher) {
-        struct Marker;
-        std::any::TypeId::of::<Marker>().hash(state);
-
-        self.size.hash(state);
     }
 }
 

--- a/src/native/ramp.rs
+++ b/src/native/ramp.rs
@@ -6,11 +6,9 @@
 use std::fmt::Debug;
 
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Hasher, Layout,
-    Length, Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
+    Point, Rectangle, Shell, Size, Widget,
 };
-
-use std::hash::Hash;
 
 use crate::core::{Normal, NormalParam};
 use crate::IntRange;
@@ -441,14 +439,6 @@ where
             &self.style,
             self.direction,
         )
-    }
-
-    fn hash_layout(&self, state: &mut Hasher) {
-        struct Marker;
-        std::any::TypeId::of::<Marker>().hash(state);
-
-        self.width.hash(state);
-        self.height.hash(state);
     }
 }
 

--- a/src/native/v_slider.rs
+++ b/src/native/v_slider.rs
@@ -5,11 +5,9 @@
 use std::fmt::Debug;
 
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Hasher, Layout,
-    Length, Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
+    Point, Rectangle, Shell, Size, Widget,
 };
-
-use std::hash::Hash;
 
 use crate::core::{ModulationRange, Normal, NormalParam};
 use crate::native::{text_marks, tick_marks};
@@ -470,14 +468,6 @@ where
             &self.state.tick_marks_cache,
             &self.state.text_marks_cache,
         )
-    }
-
-    fn hash_layout(&self, state: &mut Hasher) {
-        struct Marker;
-        std::any::TypeId::of::<Marker>().hash(state);
-
-        self.width.hash(state);
-        self.height.hash(state);
     }
 }
 

--- a/src/native/xy_pad.rs
+++ b/src/native/xy_pad.rs
@@ -6,11 +6,9 @@
 use std::fmt::Debug;
 
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Hasher, Layout,
-    Length, Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
+    Point, Rectangle, Shell, Size, Widget,
 };
-
-use std::hash::Hash;
 
 use crate::core::{Normal, NormalParam};
 use crate::IntRange;
@@ -434,13 +432,6 @@ where
             self.state.is_dragging,
             &self.style,
         )
-    }
-
-    fn hash_layout(&self, state: &mut Hasher) {
-        struct Marker;
-        std::any::TypeId::of::<Marker>().hash(state);
-
-        self.size.hash(state);
     }
 }
 


### PR DESCRIPTION
The commit is chosen to match latest iced_baseview.

Widget::hash_layout was removed in https://github.com/iced-rs/iced/pull/1263, so I removed it here.