### PR TITLE
Migration to iced's "pure" widget design

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,7 @@ members = [
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dev-dependencies]
-iced = { version = "0.4", features = ["canvas"] }
-
 [dependencies]
-iced_native = "0.5"
-iced_graphics = { version = "0.3", features = ["canvas"] }
+iced = { version = "0.5.2", features = ["canvas"] }
+iced_graphics = "0.4.0"
+iced_native = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ members = [
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { version = "0.5.2", features = ["canvas"] }
+iced = { version = "0.5.2", default-features = false, features = ["canvas"] }
 iced_graphics = "0.4.0"
 iced_native = "0.6.1"
+
+[features]
+default = ["wgpu"]
+glow = ["iced/glow"]
+wgpu = ["iced/wgpu"]

--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ you want to learn about a specific release, check out [the release list].
 This crate assumes you know the basics of how to use [Iced]. If you haven't alreay, please check it out [here].
 ```rust
 // Import iced modules.
-use iced::{
-    Align, Column, Container, Element, Length, Sandbox, Settings, Text,
-};
+use iced::widget::{column, container, text};
+use iced::{Alignment, Element, Length, Sandbox, Settings};
 // Import iced_audio modules.
 use iced_audio::{
-    h_slider, knob, tick_marks, v_slider, xy_pad, FloatRange, FreqRange,
-    HSlider, IntRange, Knob, LogDBRange, Normal, VSlider, XYPad,
+    tick_marks, FloatRange, FreqRange, HSlider, IntRange, Knob, LogDBRange,
+    Normal, NormalParam, VSlider, XYPad,
 };
 
 // The message when a parameter widget is moved by the user
@@ -98,10 +97,11 @@ pub struct App {
     freq_range: FreqRange,
 
     // The states of the widgets that will control the parameters.
-    h_slider_state: h_slider::State,
-    v_slider_state: v_slider::State,
-    knob_state: knob::State,
-    xy_pad_state: xy_pad::State,
+    h_slider_param: NormalParam,
+    v_slider_param: NormalParam,
+    knob_param: NormalParam,
+    xy_pad_x_param: NormalParam,
+    xy_pad_y_param: NormalParam,
 
     // A group of tick marks with their size and position.
     center_tick_mark: tick_marks::Group,
@@ -128,17 +128,11 @@ impl Sandbox for App {
 
             // Initialize the state of the widgets with a normalized parameter
             // that has a value and a default value.
-            h_slider_state: h_slider::State::new(int_range.normal_param(5, 5)),
-            v_slider_state: v_slider::State::new(
-                db_range.default_normal_param(),
-            ),
-            knob_state: knob::State::new(
-                freq_range.normal_param(1000.0, 1000.0),
-            ),
-            xy_pad_state: xy_pad::State::new(
-                float_range.default_normal_param(),
-                float_range.default_normal_param(),
-            ),
+            h_slider_param: int_range.normal_param(5, 5),
+            v_slider_param: db_range.default_normal_param(),
+            knob_param: freq_range.normal_param(1000.0, 1000.0),
+            xy_pad_x_param: float_range.default_normal_param(),
+            xy_pad_y_param: float_range.default_normal_param(),
 
             // Add a tick mark at the center position with the tier 2 size
             center_tick_mark: tick_marks::Group::center(tick_marks::Tier::Two),
@@ -159,20 +153,27 @@ impl Sandbox for App {
             // Now do something useful with that value!
             Message::HSliderInt(normal) => {
                 // Integer parameters must be snapped to make the widget "step" when moved.
-                self.h_slider_state.snap_visible_to(&self.int_range);
+                self.h_slider_param.update(self.int_range.snapped(normal));
 
                 let value = self.int_range.unmap_to_value(normal);
                 self.output_text = format!("HSliderInt: {}", value);
             }
             Message::VSliderDB(normal) => {
+                self.v_slider_param.update(normal);
+
                 let value = self.db_range.unmap_to_value(normal);
                 self.output_text = format!("VSliderDB: {:.3}", value);
             }
             Message::KnobFreq(normal) => {
+                self.knob_param.update(normal);
+
                 let value = self.freq_range.unmap_to_value(normal);
                 self.output_text = format!("KnobFreq: {:.2}", value);
             }
             Message::XYPadFloat(normal_x, normal_y) => {
+                self.xy_pad_x_param.update(normal_x);
+                self.xy_pad_y_param.update(normal_y);
+
                 let value_x = self.float_range.unmap_to_value(normal_x);
                 let value_y = self.float_range.unmap_to_value(normal_y);
                 self.output_text =
@@ -181,40 +182,41 @@ impl Sandbox for App {
         }
     }
 
-    fn view(&mut self) -> Element<Message> {
+    fn view(&self) -> Element<Message> {
         // Create each parameter widget, passing in the current state of the widget.
         let h_slider_widget =
-            HSlider::new(&mut self.h_slider_state, Message::HSliderInt)
+            HSlider::new(self.h_slider_param, Message::HSliderInt)
                 // Add the tick mark group to this widget.
                 .tick_marks(&self.center_tick_mark);
 
         let v_slider_widget =
-            VSlider::new(&mut self.v_slider_state, Message::VSliderDB)
+            VSlider::new(self.v_slider_param, Message::VSliderDB)
                 .tick_marks(&self.center_tick_mark);
 
-        let knob_widget = Knob::new(&mut self.knob_state, Message::KnobFreq);
+        let knob_widget =
+            Knob::new(self.knob_param, Message::KnobFreq, || None, || None);
 
-        let xy_pad_widget =
-            XYPad::new(&mut self.xy_pad_state, Message::XYPadFloat);
+        let xy_pad_widget = XYPad::new(
+            self.xy_pad_x_param,
+            self.xy_pad_y_param,
+            Message::XYPadFloat,
+        );
 
         // Push the widgets into the iced DOM
-        let content: Element<_> = Column::new()
-            .max_width(300)
-            .max_height(500)
-            .spacing(20)
-            .padding(20)
-            .align_items(Align::Center)
-            .push(h_slider_widget)
-            .push(v_slider_widget)
-            .push(knob_widget)
-            .push(xy_pad_widget)
-            .push(
-                Container::new(Text::new(&self.output_text))
-                    .width(Length::Fill),
-            )
-            .into();
+        let content = column![
+            h_slider_widget,
+            v_slider_widget,
+            knob_widget,
+            xy_pad_widget,
+            container(text(&self.output_text)).width(Length::Fill),
+        ]
+        .max_width(300)
+        .spacing(20)
+        .padding(20)
+        .align_items(Alignment::Center);
 
-        Container::new(content)
+        container(content)
+            .max_height(500)
             .width(Length::Fill)
             .height(Length::Fill)
             .center_x()
@@ -222,8 +224,6 @@ impl Sandbox for App {
             .into()
     }
 }
-
-
 ```
 
 ## VST / LV2 / AU Plugins

--- a/examples/inputs_tour/Cargo.toml
+++ b/examples/inputs_tour/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { version = "0.4", features=["image"] }
+iced = { version = "0.5.2", features=["image"] }
 iced_audio = { path = "../../" }
+iced_native = "0.6.1"

--- a/examples/inputs_tour/Cargo.toml
+++ b/examples/inputs_tour/Cargo.toml
@@ -8,6 +8,11 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { version = "0.5.2", features=["image"] }
+iced = { version = "0.5.2", default-features = false, features = ["image"] }
 iced_audio = { path = "../../" }
 iced_native = "0.6.1"
+
+[features]
+default = ["wgpu"]
+glow = ["iced_audio/glow"]
+wgpu = ["iced_audio/wgpu"]

--- a/examples/inputs_tour/src/main.rs
+++ b/examples/inputs_tour/src/main.rs
@@ -2,7 +2,6 @@ mod steps;
 mod style;
 use steps::*;
 
-use iced::theme;
 use iced::widget::{
     column, container, horizontal_space, row, scrollable, text, Button, Column,
 };
@@ -68,7 +67,7 @@ impl Sandbox for InputsTour {
             controls = controls.push(
                 button("Back")
                     .on_press(Message::BackPressed)
-                    .style(theme::Button::Secondary),
+                    .style(style::Button::Secondary.into()),
             );
         }
 
@@ -78,7 +77,7 @@ impl Sandbox for InputsTour {
             controls = controls.push(
                 button("Next")
                     .on_press(Message::NextPressed)
-                    .style(theme::Button::Primary),
+                    .style(style::Button::Primary.into()),
             );
         }
 

--- a/examples/inputs_tour/src/main.rs
+++ b/examples/inputs_tour/src/main.rs
@@ -2,11 +2,19 @@ mod steps;
 mod style;
 use steps::*;
 
-use iced::{
-    alignment::Horizontal, button, scrollable, Button, Color, Column,
-    Container, Element, Length, Row, Sandbox, Scrollable, Settings, Space,
-    Text,
+use iced::theme;
+use iced::widget::{
+    column, container, horizontal_space, row, scrollable, text, Button, Column,
 };
+use iced::{alignment, Color, Element, Length, Sandbox, Settings};
+use iced_native::widget::tree::Tag;
+use iced_native::widget::{Operation, Tree};
+use iced_native::{
+    event, layout, mouse, overlay, renderer, Clipboard, Event, Layout, Point,
+    Rectangle, Shell, Widget,
+};
+
+use std::marker::PhantomData;
 
 static STARTING_STEP: usize = 0;
 
@@ -20,9 +28,6 @@ pub fn main() {
 
 pub struct InputsTour {
     steps: Steps,
-    scroll: scrollable::State,
-    back_button: button::State,
-    next_button: button::State,
     debug: bool,
 }
 
@@ -32,9 +37,6 @@ impl Sandbox for InputsTour {
     fn new() -> InputsTour {
         InputsTour {
             steps: Steps::default(),
-            scroll: scrollable::State::new(),
-            back_button: button::State::new(),
-            next_button: button::State::new(),
             debug: false,
         }
     }
@@ -57,56 +59,49 @@ impl Sandbox for InputsTour {
         }
     }
 
-    fn view(&mut self) -> Element<Message> {
-        let InputsTour {
-            steps,
-            scroll,
-            back_button,
-            next_button,
-            ..
-        } = self;
+    fn view(&self) -> Element<Message> {
+        let InputsTour { steps, .. } = self;
 
-        let mut controls = Row::new();
+        let mut controls = row![];
 
         if steps.has_previous() {
             controls = controls.push(
-                button(back_button, "Back")
+                button("Back")
                     .on_press(Message::BackPressed)
-                    .style(style::button::Button::Secondary),
+                    .style(theme::Button::Secondary),
             );
         }
 
-        controls = controls.push(Space::with_width(Length::Fill));
+        controls = controls.push(horizontal_space(Length::Fill));
 
         if steps.can_continue() {
             controls = controls.push(
-                button(next_button, "Next")
+                button("Next")
                     .on_press(Message::NextPressed)
-                    .style(style::button::Button::Primary),
+                    .style(theme::Button::Primary),
             );
         }
 
-        let content: Element<_> = Column::new()
-            .max_width(540)
-            .spacing(20)
-            .padding(20)
-            .push(steps.view(self.debug).map(Message::StepMessage))
-            .push(controls)
-            .into();
+        let content: Element<_> = column![
+            steps.view(self.debug).map(Message::StepMessage),
+            controls,
+        ]
+        .max_width(540)
+        .spacing(20)
+        .padding(20)
+        .into();
 
-        let content = if self.debug {
-            content.explain(Color::BLACK)
-        } else {
-            content
-        };
+        let scrollable = scrollable(
+            container(if self.debug {
+                content.explain(Color::BLACK)
+            } else {
+                content
+            })
+            .width(Length::Fill)
+            .center_x(),
+        );
 
-        let scrollable = Scrollable::new(scroll)
-            .push(Container::new(content).width(Length::Fill).center_x());
-
-        Container::new(scrollable)
-            .height(Length::Fill)
-            .center_y()
-            .into()
+        container(scrollable).height(Length::Fill).center_y().into()
     }
 }
 
@@ -144,7 +139,7 @@ impl Steps {
         self.steps[self.current].update(msg, debug);
     }
 
-    fn view(&mut self, debug: bool) -> Element<StepMessage> {
+    fn view(&self, debug: bool) -> Element<StepMessage> {
         self.steps[self.current].view(debug)
     }
 
@@ -241,7 +236,7 @@ impl<'a> Step {
         }
     }
 
-    fn view(&mut self, debug: bool) -> Element<StepMessage> {
+    fn view(&self, debug: bool) -> Element<StepMessage> {
         match self {
             Step::Welcome => Self::welcome(),
             Step::HSliders(step) => {
@@ -260,23 +255,19 @@ impl<'a> Step {
         .into()
     }
 
-    pub fn container<Msg>(title: &str) -> Column<'a, Msg> {
-        Column::new().spacing(20).push(Text::new(title).size(44))
-    }
-
     fn welcome() -> Element<'a, StepMessage> {
-        Self::container("Welcome!")
-            .push(Text::new(
+        StepContainer::<Self, _, _>::new("Welcome!")
+            .push(text(
                 "This is a simple tour showcasing basic input widgets \
                 designed specifically for audio software applications such as \
                 VST / LV2 plugins.",
             ))
-            .push(Text::new(
+            .push(text(
                 "Iced is a cross-platform GUI library for Rust focused on \
                 simplicity and type-safety. It is heavily inspired by Elm. \
                 Iced Audio is an extension for Iced.",
             ))
-            .push(Text::new(
+            .push(text(
                 "For each control, holding down the Ctrl key will make fine \
                 adjustments, and double-clicking will set the control to its \
                 default value.",
@@ -285,13 +276,172 @@ impl<'a> Step {
     }
 }
 
-fn button<'a, Message: Clone>(
-    state: &'a mut button::State,
-    label: &str,
-) -> Button<'a, Message> {
-    Button::new(
-        state,
-        Text::new(label).horizontal_alignment(Horizontal::Center),
+/// A Container for `Step` implementations.
+///
+/// Due to `Tree` diff implementation, when switching `Step`s:
+/// for all the container's children of the same type and
+/// in the same position as in previous `Step` `Container`,
+/// the `State` is not reset.
+///
+/// This `struct` uses the type of the `Step` implementation to
+/// form a specific `Tag` which forces the tree to be rebuilt
+/// when switching `Step`s.
+pub struct StepContainer<'a, Step, Message, Renderer> {
+    col: Column<'a, Message, Renderer>,
+    step_type: PhantomData<Step>,
+}
+
+impl<'a, Step, Message, Renderer> StepContainer<'a, Step, Message, Renderer>
+where
+    Step: 'static,
+    Renderer: 'a + iced_native::text::Renderer,
+    Renderer::Theme: iced_native::widget::text::StyleSheet,
+{
+    /// Builds a new step container for the step implementation with the provided title.
+    pub fn new(title: &str) -> Self {
+        Self {
+            col: column![text(title).size(44)].spacing(20),
+            step_type: PhantomData,
+        }
+    }
+
+    pub fn push(
+        self,
+        child: impl Into<Element<'a, Message, Renderer>>,
+    ) -> Self {
+        Self {
+            col: self.col.push(child),
+            step_type: PhantomData,
+        }
+    }
+}
+
+impl<'a, Step, Message, Renderer> Widget<Message, Renderer>
+    for StepContainer<'a, Step, Message, Renderer>
+where
+    Step: 'static,
+    Renderer: iced_native::Renderer,
+{
+    fn tag(&self) -> Tag {
+        // Force the `Tag` to be `Step`-implementation dependent.
+        Tag::of::<Step>()
+    }
+
+    // Defere the rest of the `Widget` implementation to the inner `Column`.
+    fn children(&self) -> Vec<Tree> {
+        self.col.children()
+    }
+    fn diff(&self, tree: &mut Tree) {
+        Widget::diff(&self.col, tree)
+    }
+    fn width(&self) -> Length {
+        Widget::width(&self.col)
+    }
+    fn height(&self) -> Length {
+        Widget::height(&self.col)
+    }
+    fn layout(
+        &self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        Widget::layout(&self.col, renderer, limits)
+    }
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        operation: &mut dyn Operation<Message>,
+    ) {
+        Widget::operate(&self.col, tree, layout, operation);
+    }
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        Widget::on_event(
+            &mut self.col,
+            tree,
+            event,
+            layout,
+            cursor_position,
+            renderer,
+            clipboard,
+            shell,
+        )
+    }
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        Widget::mouse_interaction(
+            &self.col,
+            tree,
+            layout,
+            cursor_position,
+            viewport,
+            renderer,
+        )
+    }
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Renderer::Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        viewport: &Rectangle,
+    ) {
+        Widget::draw(
+            &self.col,
+            tree,
+            renderer,
+            theme,
+            style,
+            layout,
+            cursor_position,
+            viewport,
+        );
+    }
+    fn overlay<'b>(
+        &'b self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        Widget::overlay(&self.col, tree, layout, renderer)
+    }
+}
+
+impl<'a, Step, Message, Renderer>
+    From<StepContainer<'a, Step, Message, Renderer>>
+    for Element<'a, Message, Renderer>
+where
+    Step: 'static,
+    Message: 'a + Clone,
+    Renderer: 'a + iced_native::Renderer,
+{
+    fn from(
+        step_container: StepContainer<'a, Step, Message, Renderer>,
+    ) -> Element<'a, Message, Renderer> {
+        Element::new(step_container)
+    }
+}
+
+fn button<'a, Message: Clone>(label: &str) -> Button<'a, Message> {
+    iced::widget::button(
+        text(label).horizontal_alignment(alignment::Horizontal::Center),
     )
     .padding(12)
     .width(Length::Units(100))

--- a/examples/inputs_tour/src/steps/step_knobs.rs
+++ b/examples/inputs_tour/src/steps/step_knobs.rs
@@ -225,67 +225,38 @@ impl KnobStep {
         // create each of the Knob widgets, passing in the value of
         // the corresponding parameter
 
-        let knob_float =
-            Knob::new(self.knob_float_param, Message::Float, || None, || None)
-                .tick_marks(&self.float_tick_marks)
-                .text_marks(&self.float_text_marks);
+        let knob_float = Knob::new(self.knob_float_param, Message::Float)
+            .tick_marks(&self.float_tick_marks)
+            .text_marks(&self.float_text_marks);
 
-        let knob_int =
-            Knob::new(self.knob_int_param, Message::Int, || None, || None)
-                .tick_marks(&self.int_tick_marks)
-                .text_marks(&self.int_text_marks);
+        let knob_int = Knob::new(self.knob_int_param, Message::Int)
+            .tick_marks(&self.int_tick_marks)
+            .text_marks(&self.int_text_marks);
 
-        let knob_db =
-            Knob::new(self.knob_db_param, Message::DB, || None, || None)
-                .tick_marks(&self.db_tick_marks)
-                .text_marks(&self.db_text_marks);
+        let knob_db = Knob::new(self.knob_db_param, Message::DB)
+            .tick_marks(&self.db_tick_marks)
+            .text_marks(&self.db_text_marks);
 
-        let knob_freq =
-            Knob::new(self.knob_freq_param, Message::Freq, || None, || None)
-                .tick_marks(&self.freq_tick_marks)
-                .text_marks(&self.freq_text_marks);
+        let knob_freq = Knob::new(self.knob_freq_param, Message::Freq)
+            .tick_marks(&self.freq_tick_marks)
+            .text_marks(&self.freq_text_marks);
 
-        let knob_style1 = Knob::new(
-            self.knob_style1_param,
-            Message::Style1,
-            || None,
-            || None,
-        )
-        .style(style::knob::CustomStyleCircle)
-        .text_marks(&self.float_text_marks);
+        let knob_style1 = Knob::new(self.knob_style1_param, Message::Style1)
+            .style(style::knob::CustomStyleCircle)
+            .text_marks(&self.float_text_marks);
 
-        let knob_style2 = Knob::new(
-            self.knob_style2_param,
-            Message::Style2,
-            || None,
-            || None,
-        )
-        .style(style::knob::CustomStyleLine);
+        let knob_style2 = Knob::new(self.knob_style2_param, Message::Style2)
+            .style(style::knob::CustomStyleLine);
 
-        let knob_style3 = Knob::new(
-            self.knob_style3_param,
-            Message::Style3,
-            || None,
-            || None,
-        )
-        .style(style::knob::CustomArc);
+        let knob_style3 = Knob::new(self.knob_style3_param, Message::Style3)
+            .style(style::knob::CustomArc);
 
-        let knob_style4 = Knob::new(
-            self.knob_style4_param,
-            Message::Style4,
-            || None,
-            || None,
-        )
-        .style(style::knob::CustomArcBipolar);
+        let knob_style4 = Knob::new(self.knob_style4_param, Message::Style4)
+            .style(style::knob::CustomArcBipolar);
 
-        let knob_style5 = Knob::new(
-            self.knob_style5_param,
-            Message::Style5,
-            || None,
-            || None,
-        )
-        .bipolar_center(Normal::new(0.2))
-        .style(style::knob::CustomArcBipolar);
+        let knob_style5 = Knob::new(self.knob_style5_param, Message::Style5)
+            .bipolar_center(Normal::new(0.2))
+            .style(style::knob::CustomArcBipolar);
 
         // push the widgets into rows
         let knob_row = row![

--- a/examples/inputs_tour/src/steps/step_mod_ranges.rs
+++ b/examples/inputs_tour/src/steps/step_mod_ranges.rs
@@ -2,7 +2,7 @@ use iced::widget::{checkbox, column, container, row, text};
 use iced::{Alignment, Element, Length};
 
 use iced_audio::{
-    mod_range_input, FloatRange, HSlider, Knob, ModRangeInput, ModulationRange,
+    style::theme, FloatRange, HSlider, Knob, ModRangeInput, ModulationRange,
     Normal, NormalParam, VSlider,
 };
 
@@ -254,7 +254,7 @@ impl ModRanges {
         let auto_input2 =
             ModRangeInput::new(self.auto_input2_param, Message::ModRangeInput2)
                 .size(Length::from(15))
-                .style(mod_range_input::DefaultInvisible);
+                .style(theme::ModRangeInput::Invisible);
 
         let knob_auto2 = Knob::new(
             self.knob_auto2_param,

--- a/examples/inputs_tour/src/steps/step_mod_ranges.rs
+++ b/examples/inputs_tour/src/steps/step_mod_ranges.rs
@@ -213,20 +213,13 @@ impl ModRanges {
         // create each of the Knob widgets, passing in the value of
         // the corresponding parameter
 
-        let knob_start = Knob::new(
-            self.knob_start_param,
-            Message::RangeStart,
-            || None,
-            || None,
-        );
+        let knob_start = Knob::new(self.knob_start_param, Message::RangeStart);
 
-        let knob_end =
-            Knob::new(self.knob_end_param, Message::RangeEnd, || None, || None);
+        let knob_end = Knob::new(self.knob_end_param, Message::RangeEnd);
 
-        let knob1 =
-            Knob::new(self.knob1_param, Message::Knob1, || None, || None)
-                .mod_range(&self.mod_range_1)
-                .style(style::knob::CustomArc);
+        let knob1 = Knob::new(self.knob1_param, Message::Knob1)
+            .mod_range(&self.mod_range_1)
+            .style(style::knob::CustomArc);
 
         let h_slider1 = HSlider::new(self.h_slider1_param, Message::HSlider1)
             .mod_range(&self.mod_range_1)
@@ -242,28 +235,18 @@ impl ModRanges {
                 .size(Length::from(10))
                 .style(style::mod_range_input::CustomStyle);
 
-        let knob_auto1 = Knob::new(
-            self.knob_auto1_param,
-            Message::ModKnob1,
-            || None,
-            || None,
-        )
-        .mod_range(&self.knob_auto1_mod_range)
-        .style(style::knob::CustomStyleCircle);
+        let knob_auto1 = Knob::new(self.knob_auto1_param, Message::ModKnob1)
+            .mod_range(&self.knob_auto1_mod_range)
+            .style(style::knob::CustomStyleCircle);
 
         let auto_input2 =
             ModRangeInput::new(self.auto_input2_param, Message::ModRangeInput2)
                 .size(Length::from(15))
                 .style(theme::ModRangeInput::Invisible);
 
-        let knob_auto2 = Knob::new(
-            self.knob_auto2_param,
-            Message::ModKnob2,
-            || None,
-            || None,
-        )
-        .mod_range(&self.knob_auto2_mod_range)
-        .style(style::knob::CustomStyleCircle);
+        let knob_auto2 = Knob::new(self.knob_auto2_param, Message::ModKnob2)
+            .mod_range(&self.knob_auto2_mod_range)
+            .style(style::knob::CustomStyleCircle);
 
         // push the widgets into rows
         let knob_row = row![

--- a/examples/inputs_tour/src/steps/step_ramps.rs
+++ b/examples/inputs_tour/src/steps/step_ramps.rs
@@ -1,8 +1,9 @@
-use iced::{Column, Element, Length, Row, Text};
+use iced::widget::{column, row, text};
+use iced::{Element, Length};
 
-use iced_audio::{ramp, FloatRange, Normal, Ramp};
+use iced_audio::{ramp, FloatRange, Normal, NormalParam, Ramp};
 
-use crate::{style, Step};
+use crate::{style, StepContainer};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -15,10 +16,10 @@ pub enum Message {
 pub struct RampStep {
     float_range: FloatRange,
 
-    ramp_default_up_state: ramp::State,
-    ramp_default_down_state: ramp::State,
-    ramp_custom_up_state: ramp::State,
-    ramp_custom_down_state: ramp::State,
+    ramp_default_up_param: NormalParam,
+    ramp_default_down_param: NormalParam,
+    ramp_custom_up_param: NormalParam,
+    ramp_custom_down_param: NormalParam,
 
     output_text: String,
 }
@@ -35,21 +36,10 @@ impl Default for RampStep {
             float_range,
 
             // initialize the state of the ramp widget
-            ramp_default_up_state: ramp::State::new(
-                float_range.default_normal_param(),
-            ),
-
-            ramp_default_down_state: ramp::State::new(
-                float_range.default_normal_param(),
-            ),
-
-            ramp_custom_up_state: ramp::State::new(
-                float_range.default_normal_param(),
-            ),
-
-            ramp_custom_down_state: ramp::State::new(
-                float_range.default_normal_param(),
-            ),
+            ramp_default_up_param: float_range.default_normal_param(),
+            ramp_default_down_param: float_range.default_normal_param(),
+            ramp_custom_up_param: float_range.default_normal_param(),
+            ramp_custom_down_param: float_range.default_normal_param(),
 
             output_text: String::from("Move a widget"),
         }
@@ -64,24 +54,32 @@ impl RampStep {
     pub fn update(&mut self, message: Message) {
         match message {
             Message::DefaultUp(normal) => {
+                self.ramp_default_up_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "DefaultUp",
                     self.float_range.unmap_to_value(normal),
                 );
             }
             Message::DefaultDown(normal) => {
+                self.ramp_default_down_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "DefaultDown",
                     self.float_range.unmap_to_value(normal),
                 );
             }
             Message::CustomUp(normal) => {
+                self.ramp_custom_up_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "CutomUp",
                     self.float_range.unmap_to_value(normal),
                 );
             }
             Message::CustomDown(normal) => {
+                self.ramp_custom_down_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "CustomDown",
                     self.float_range.unmap_to_value(normal),
@@ -90,64 +88,63 @@ impl RampStep {
         }
     }
 
-    pub fn view(&mut self, _debug: bool) -> Element<Message> {
+    pub fn view(&self, _debug: bool) -> Element<Message> {
         // create each of the Ramp widgets, passing in the value of
         // the corresponding parameter
 
         let ramp_default_up = Ramp::new(
-            &mut self.ramp_default_up_state,
+            self.ramp_default_up_param,
             Message::DefaultUp,
             ramp::RampDirection::Up,
         );
 
         let ramp_default_down = Ramp::new(
-            &mut self.ramp_default_down_state,
+            self.ramp_default_down_param,
             Message::DefaultDown,
             ramp::RampDirection::Down,
         );
 
         let ramp_custom_up = Ramp::new(
-            &mut self.ramp_custom_up_state,
+            self.ramp_custom_up_param,
             Message::CustomUp,
             ramp::RampDirection::Up,
         )
         .style(style::ramp::CustomStyle);
 
         let ramp_custom_down = Ramp::new(
-            &mut self.ramp_custom_down_state,
+            self.ramp_custom_down_param,
             Message::CustomDown,
             ramp::RampDirection::Down,
         )
         .style(style::ramp::CustomStyle);
 
         // push the widgets into rows
-        let ramp_row = Row::new()
-            .spacing(20)
-            .push(
-                Column::new()
-                    .width(Length::Fill)
-                    .spacing(10)
-                    .push(Text::new("Default Style Up"))
-                    .push(ramp_default_up)
-                    .push(Text::new("Default Style Down"))
-                    .push(ramp_default_down),
-            )
-            .push(
-                Column::new()
-                    .width(Length::Fill)
-                    .spacing(10)
-                    .push(Text::new("Custom Style Up"))
-                    .push(ramp_custom_up)
-                    .push(Text::new("Custom Style Down"))
-                    .push(ramp_custom_down),
-            );
+        let ramp_row = row![
+            column![
+                text("Default Style Up"),
+                ramp_default_up,
+                text("Default Style Down"),
+                ramp_default_down,
+            ]
+            .width(Length::Fill)
+            .spacing(10),
+            column![
+                text("Custom Style Up"),
+                ramp_custom_up,
+                text("Custom Style Down"),
+                ramp_custom_down,
+            ]
+            .width(Length::Fill)
+            .spacing(10),
+        ]
+        .spacing(20);
 
-        let content = Column::new()
+        let content = column![ramp_row, text(&self.output_text).size(16),]
             .spacing(20)
-            .padding(20)
-            .push(ramp_row)
-            .push(Text::new(&self.output_text).size(16));
+            .padding(20);
 
-        Step::container("Ramps").push(content).into()
+        StepContainer::<Self, _, _>::new("Ramps")
+            .push(content)
+            .into()
     }
 }

--- a/examples/inputs_tour/src/steps/step_v_sliders.rs
+++ b/examples/inputs_tour/src/steps/step_v_sliders.rs
@@ -1,11 +1,12 @@
-use iced::{image, Column, Element, Length, Rectangle, Row, Text};
+use iced::widget::{column, container, image, row, text};
+use iced::{Element, Length, Rectangle};
 
 use iced_audio::{
-    text_marks, tick_marks, v_slider, FloatRange, FreqRange, IntRange,
-    LogDBRange, Normal, VSlider,
+    text_marks, tick_marks, FloatRange, FreqRange, IntRange, LogDBRange,
+    Normal, NormalParam, VSlider,
 };
 
-use crate::{style, Step};
+use crate::{style, StepContainer};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -24,13 +25,13 @@ pub struct VSliderStep {
     db_range: LogDBRange,
     freq_range: FreqRange,
 
-    v_slider_float_state: v_slider::State,
-    v_slider_int_state: v_slider::State,
-    v_slider_db_state: v_slider::State,
-    v_slider_freq_state: v_slider::State,
-    v_slider_rect_state: v_slider::State,
-    v_slider_rect_bp_state: v_slider::State,
-    v_slider_texture_state: v_slider::State,
+    float_param: NormalParam,
+    int_param: NormalParam,
+    db_param: NormalParam,
+    freq_param: NormalParam,
+    rect_param: NormalParam,
+    rect_bp_param: NormalParam,
+    texture_param: NormalParam,
 
     v_slider_texture_handle: image::Handle,
 
@@ -64,34 +65,14 @@ impl Default for VSliderStep {
             db_range,
             freq_range,
 
-            // initialize the state of the VSlider widget
-            v_slider_float_state: v_slider::State::new(
-                float_range.default_normal_param(),
-            ),
-
-            v_slider_int_state: v_slider::State::new(
-                int_range.default_normal_param(),
-            ),
-
-            v_slider_db_state: v_slider::State::new(
-                db_range.default_normal_param(),
-            ),
-
-            v_slider_freq_state: v_slider::State::new(
-                freq_range.normal_param(1000.0, 1000.0),
-            ),
-
-            v_slider_rect_state: v_slider::State::new(
-                float_range.default_normal_param(),
-            ),
-
-            v_slider_rect_bp_state: v_slider::State::new(
-                float_range.default_normal_param(),
-            ),
-
-            v_slider_texture_state: v_slider::State::new(
-                float_range.default_normal_param(),
-            ),
+            // initialize the parameter of the VSlider widget
+            float_param: float_range.default_normal_param(),
+            int_param: int_range.default_normal_param(),
+            db_param: db_range.default_normal_param(),
+            freq_param: freq_range.normal_param(1000.0, 1000.0),
+            rect_param: float_range.default_normal_param(),
+            rect_bp_param: float_range.default_normal_param(),
+            texture_param: float_range.default_normal_param(),
 
             v_slider_texture_handle: format!(
                 "{}/../images/iced_v_slider.png",
@@ -167,6 +148,8 @@ impl VSliderStep {
     pub fn update(&mut self, message: Message) {
         match message {
             Message::Float(normal) => {
+                self.float_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "VSliderFloat",
                     self.float_range.unmap_to_value(normal),
@@ -174,7 +157,7 @@ impl VSliderStep {
             }
             Message::Int(normal) => {
                 // Integer parameters must be snapped to make the widget "step" when moved.
-                self.v_slider_int_state.snap_visible_to(&self.int_range);
+                self.int_param.update(self.int_range.snapped(normal));
 
                 self.output_text = crate::info_text_i32(
                     "VSliderInt",
@@ -182,30 +165,40 @@ impl VSliderStep {
                 );
             }
             Message::DB(normal) => {
+                self.db_param.update(normal);
+
                 self.output_text = crate::info_text_db(
                     "VSliderDB",
                     self.db_range.unmap_to_value(normal),
                 );
             }
             Message::Freq(normal) => {
+                self.freq_param.update(normal);
+
                 self.output_text = crate::info_text_freq(
                     "VSliderFreq",
                     self.freq_range.unmap_to_value(normal),
                 );
             }
             Message::RectStyle(normal) => {
+                self.rect_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "VSliderRect",
                     self.float_range.unmap_to_value(normal),
                 );
             }
             Message::RectBipolarStyle(normal) => {
+                self.rect_bp_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "VSliderBipolar",
                     self.float_range.unmap_to_value(normal),
                 );
             }
             Message::TextureStyle(normal) => {
+                self.texture_param.update(normal);
+
                 self.output_text = crate::info_text_f32(
                     "VSliderTexture",
                     self.float_range.unmap_to_value(normal),
@@ -214,113 +207,98 @@ impl VSliderStep {
         }
     }
 
-    pub fn view(&mut self, _debug: bool) -> Element<Message> {
+    pub fn view(&self, _debug: bool) -> Element<Message> {
         // create each of the VSlider widgets, passing in the value of
         // the corresponding parameter
 
-        let v_slider_float =
-            VSlider::new(&mut self.v_slider_float_state, Message::Float)
-                .tick_marks(&self.float_tick_marks)
-                .text_marks(&self.float_text_marks);
+        let v_slider_float = VSlider::new(self.float_param, Message::Float)
+            .tick_marks(&self.float_tick_marks)
+            .text_marks(&self.float_text_marks);
 
-        let v_slider_int =
-            VSlider::new(&mut self.v_slider_int_state, Message::Int)
-                .tick_marks(&self.int_tick_marks)
-                .text_marks(&self.int_text_marks);
+        let v_slider_int = VSlider::new(self.int_param, Message::Int)
+            .tick_marks(&self.int_tick_marks)
+            .text_marks(&self.int_text_marks);
 
-        let v_slider_db =
-            VSlider::new(&mut self.v_slider_db_state, Message::DB)
-                .tick_marks(&self.db_tick_marks)
-                .text_marks(&self.db_text_marks);
+        let v_slider_db = VSlider::new(self.db_param, Message::DB)
+            .tick_marks(&self.db_tick_marks)
+            .text_marks(&self.db_text_marks);
 
-        let v_slider_freq =
-            VSlider::new(&mut self.v_slider_freq_state, Message::Freq)
-                .tick_marks(&self.freq_tick_marks)
-                .text_marks(&self.freq_text_marks);
+        let v_slider_freq = VSlider::new(self.freq_param, Message::Freq)
+            .tick_marks(&self.freq_tick_marks)
+            .text_marks(&self.freq_text_marks);
 
-        let v_slider_rect =
-            VSlider::new(&mut self.v_slider_rect_state, Message::RectStyle)
+        let v_slider_rect = VSlider::new(self.rect_param, Message::RectStyle)
+            .width(Length::from(Length::Units(24)))
+            .style(style::v_slider::RectStyle);
+
+        let v_slider_rect_bp =
+            VSlider::new(self.rect_bp_param, Message::RectBipolarStyle)
                 .width(Length::from(Length::Units(24)))
-                .style(style::v_slider::RectStyle);
+                .style(style::v_slider::RectBipolarStyle);
 
-        let v_slider_rect_bp = VSlider::new(
-            &mut self.v_slider_rect_bp_state,
-            Message::RectBipolarStyle,
-        )
-        .width(Length::from(Length::Units(24)))
-        .style(style::v_slider::RectBipolarStyle);
-
-        let v_slider_texture = VSlider::new(
-            &mut self.v_slider_texture_state,
-            Message::TextureStyle,
-        )
-        .tick_marks(&self.float_tick_marks)
-        .text_marks(&self.float_text_marks)
-        // the width of the texture
-        .width(Length::from(Length::Units(20)))
-        .style(style::v_slider::TextureStyle(
-            // clone the handle to the loaded texture
-            self.v_slider_texture_handle.clone(),
-            // bounds of the texture, where the origin is in the center
-            // of the image
-            Rectangle {
-                x: -20.0 / 2.0,
-                y: -38.0 / 2.0,
-                width: 20.0,
-                height: 38.0,
-            },
-        ));
+        let v_slider_texture =
+            VSlider::new(self.texture_param, Message::TextureStyle)
+                .tick_marks(&self.float_tick_marks)
+                .text_marks(&self.float_text_marks)
+                // the width of the texture
+                .width(Length::from(Length::Units(20)))
+                .style(style::v_slider::TextureStyle(
+                    // clone the handle to the loaded texture
+                    self.v_slider_texture_handle.clone(),
+                    // bounds of the texture, where the origin is in the center
+                    // of the image
+                    Rectangle {
+                        x: -20.0 / 2.0,
+                        y: -38.0 / 2.0,
+                        width: 20.0,
+                        height: 38.0,
+                    },
+                ));
 
         // push the widgets into rows
-        let v_slider_row = Row::new()
-            .spacing(20)
-            .max_height(400)
-            .push(
-                Column::new()
+        let v_slider_row = container(
+            row![
+                column![
+                    text("Float Range"),
+                    v_slider_float,
+                    text("Log DB Range"),
+                    v_slider_db,
+                ]
+                .max_width(120)
+                .height(Length::Fill)
+                .spacing(10),
+                column![
+                    text("Custom Style"),
+                    v_slider_rect,
+                    text("Custom Texture Style"),
+                    v_slider_texture,
+                ]
+                .max_width(120)
+                .height(Length::Fill)
+                .spacing(10),
+                column![
+                    text("Int Range"),
+                    v_slider_int,
+                    text("Freq Range"),
+                    v_slider_freq,
+                ]
+                .max_width(120)
+                .height(Length::Fill)
+                .spacing(10),
+                column![text("Custom Bipolar Style"), v_slider_rect_bp,]
                     .max_width(120)
                     .height(Length::Fill)
-                    .spacing(10)
-                    .push(Text::new("Float Range"))
-                    .push(v_slider_float)
-                    .push(Text::new("Log DB Range"))
-                    .push(v_slider_db),
-            )
-            .push(
-                Column::new()
-                    .max_width(120)
-                    .height(Length::Fill)
-                    .spacing(10)
-                    .push(Text::new("Custom Style"))
-                    .push(v_slider_rect)
-                    .push(Text::new("Custom Texture Style"))
-                    .push(v_slider_texture),
-            )
-            .push(
-                Column::new()
-                    .max_width(120)
-                    .height(Length::Fill)
-                    .spacing(10)
-                    .push(Text::new("Int Range"))
-                    .push(v_slider_int)
-                    .push(Text::new("Freq Range"))
-                    .push(v_slider_freq),
-            )
-            .push(
-                Column::new()
-                    .max_width(120)
-                    .height(Length::Fill)
-                    .spacing(10)
-                    .push(Text::new("Custom Bipolar Style"))
-                    .push(v_slider_rect_bp),
-            );
+                    .spacing(10),
+            ]
+            .spacing(20),
+        )
+        .max_height(400);
 
-        let content = Column::new()
+        let content = column![v_slider_row, text(&self.output_text).size(16),]
             .spacing(20)
-            .padding(20)
-            .push(v_slider_row)
-            .push(Text::new(&self.output_text).size(16));
+            .padding(20);
 
-        Step::container("Vertical Sliders (VSlider)")
+        StepContainer::<Self, _, _>::new("Vertical Sliders (VSlider)")
             .push(content)
             .into()
     }

--- a/examples/inputs_tour/src/style/button.rs
+++ b/examples/inputs_tour/src/style/button.rs
@@ -1,4 +1,4 @@
-use iced::{button, Background, Color, Vector};
+use iced::{widget::button, Background, Color, Vector};
 
 use super::colors;
 
@@ -8,8 +8,10 @@ pub enum Button {
 }
 
 impl button::StyleSheet for Button {
-    fn active(&self) -> button::Style {
-        button::Style {
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> button::Appearance {
+        button::Appearance {
             background: Some(Background::Color(match self {
                 Button::Primary => colors::BUTTON_PRIMARY,
                 Button::Secondary => colors::BUTTON_SECONDARY,
@@ -17,15 +19,21 @@ impl button::StyleSheet for Button {
             border_radius: 12.0,
             shadow_offset: Vector::new(1.0, 1.0),
             text_color: Color::from_rgb8(0xEE, 0xEE, 0xEE),
-            ..button::Style::default()
+            ..button::Appearance::default()
         }
     }
 
-    fn hovered(&self) -> button::Style {
-        button::Style {
+    fn hovered(&self, style: &Self::Style) -> button::Appearance {
+        button::Appearance {
             text_color: Color::WHITE,
             shadow_offset: Vector::new(1.0, 2.0),
-            ..self.active()
+            ..self.active(style)
         }
+    }
+}
+
+impl From<Button> for iced::theme::Button {
+    fn from(style: Button) -> Self {
+        iced::theme::Button::Custom(Box::new(style))
     }
 }

--- a/examples/inputs_tour/src/style/colors.rs
+++ b/examples/inputs_tour/src/style/colors.rs
@@ -1,5 +1,6 @@
 use iced::Color;
 
+/* FIXME commented out due to new style handling in iced.
 pub const BUTTON_PRIMARY: Color = Color::from_rgb(
     0x32 as f32 / 255.0,
     0x80 as f32 / 255.0,
@@ -11,6 +12,7 @@ pub const BUTTON_SECONDARY: Color = Color::from_rgb(
     0x69 as f32 / 255.0,
     0x73 as f32 / 255.0,
 );
+*/
 
 pub const EMPTY: Color = Color::from_rgb(
     0x42 as f32 / 255.0,

--- a/examples/inputs_tour/src/style/colors.rs
+++ b/examples/inputs_tour/src/style/colors.rs
@@ -1,6 +1,5 @@
 use iced::Color;
 
-/* FIXME commented out due to new style handling in iced.
 pub const BUTTON_PRIMARY: Color = Color::from_rgb(
     0x32 as f32 / 255.0,
     0x80 as f32 / 255.0,
@@ -12,7 +11,6 @@ pub const BUTTON_SECONDARY: Color = Color::from_rgb(
     0x69 as f32 / 255.0,
     0x73 as f32 / 255.0,
 );
-*/
 
 pub const EMPTY: Color = Color::from_rgb(
     0x42 as f32 / 255.0,

--- a/examples/inputs_tour/src/style/h_slider.rs
+++ b/examples/inputs_tour/src/style/h_slider.rs
@@ -1,4 +1,5 @@
-use iced::{image, Color, Rectangle};
+use iced::widget::image;
+use iced::{Color, Rectangle};
 use iced_audio::{h_slider, text_marks, tick_marks, Offset};
 
 use super::colors;

--- a/examples/inputs_tour/src/style/h_slider.rs
+++ b/examples/inputs_tour/src/style/h_slider.rs
@@ -20,23 +20,28 @@ impl RectStyle {
     };
 }
 impl h_slider::StyleSheet for RectStyle {
-    fn active(&self) -> h_slider::Style {
-        h_slider::Style::Rect(Self::ACTIVE_RECT_STYLE)
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> h_slider::Appearance {
+        h_slider::Appearance::Rect(Self::ACTIVE_RECT_STYLE)
     }
 
-    fn hovered(&self) -> h_slider::Style {
-        h_slider::Style::Rect(h_slider::RectStyle {
+    fn hovered(&self, _style: &Self::Style) -> h_slider::Appearance {
+        h_slider::Appearance::Rect(h_slider::RectStyle {
             filled_color: colors::FILLED_HOVER,
             handle_width: 5,
             ..Self::ACTIVE_RECT_STYLE
         })
     }
 
-    fn dragging(&self) -> h_slider::Style {
-        self.hovered()
+    fn dragging(&self, style: &Self::Style) -> h_slider::Appearance {
+        self.hovered(style)
     }
 
-    fn mod_range_style(&self) -> Option<h_slider::ModRangeStyle> {
+    fn mod_range_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<h_slider::ModRangeStyle> {
         Some(h_slider::ModRangeStyle {
             placement: h_slider::ModRangePlacement::Bottom {
                 height: 3.0,
@@ -72,12 +77,14 @@ impl RectBipolarStyle {
         };
 }
 impl h_slider::StyleSheet for RectBipolarStyle {
-    fn active(&self) -> h_slider::Style {
-        h_slider::Style::RectBipolar(Self::ACTIVE_RECT_STYLE)
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> h_slider::Appearance {
+        h_slider::Appearance::RectBipolar(Self::ACTIVE_RECT_STYLE)
     }
 
-    fn hovered(&self) -> h_slider::Style {
-        h_slider::Style::RectBipolar(h_slider::RectBipolarStyle {
+    fn hovered(&self, _style: &Self::Style) -> h_slider::Appearance {
+        h_slider::Appearance::RectBipolar(h_slider::RectBipolarStyle {
             left_filled_color: colors::FILLED_HOVER,
             right_filled_color: Color::from_rgb(0.0, 0.64, 0.0),
             handle_width: 5,
@@ -85,8 +92,8 @@ impl h_slider::StyleSheet for RectBipolarStyle {
         })
     }
 
-    fn dragging(&self) -> h_slider::Style {
-        self.hovered()
+    fn dragging(&self, style: &Self::Style) -> h_slider::Appearance {
+        self.hovered(style)
     }
 }
 
@@ -94,8 +101,10 @@ impl h_slider::StyleSheet for RectBipolarStyle {
 
 pub struct TextureStyle(pub image::Handle, pub Rectangle);
 impl h_slider::StyleSheet for TextureStyle {
-    fn active(&self) -> h_slider::Style {
-        h_slider::Style::Texture(h_slider::TextureStyle {
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> h_slider::Appearance {
+        h_slider::Appearance::Texture(h_slider::TextureStyle {
             rail: h_slider::ClassicRail {
                 rail_colors: (
                     [0.0, 0.0, 0.0, 0.9].into(),
@@ -110,15 +119,18 @@ impl h_slider::StyleSheet for TextureStyle {
         })
     }
 
-    fn hovered(&self) -> h_slider::Style {
-        self.active()
+    fn hovered(&self, style: &Self::Style) -> h_slider::Appearance {
+        self.active(style)
     }
 
-    fn dragging(&self) -> h_slider::Style {
-        self.active()
+    fn dragging(&self, style: &Self::Style) -> h_slider::Appearance {
+        self.active(style)
     }
 
-    fn tick_marks_style(&self) -> Option<h_slider::TickMarksStyle> {
+    fn tick_marks_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<h_slider::TickMarksStyle> {
         Some(h_slider::TickMarksStyle {
             style: tick_marks::Style {
                 tier_1: tick_marks::Shape::Line {
@@ -145,7 +157,10 @@ impl h_slider::StyleSheet for TextureStyle {
         })
     }
 
-    fn text_marks_style(&self) -> Option<h_slider::TextMarksStyle> {
+    fn text_marks_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<h_slider::TextMarksStyle> {
         Some(h_slider::TextMarksStyle {
             style: text_marks::Style {
                 color: [0.16, 0.16, 0.16, 0.9].into(),

--- a/examples/inputs_tour/src/style/knob.rs
+++ b/examples/inputs_tour/src/style/knob.rs
@@ -22,12 +22,14 @@ impl CustomStyleCircle {
     };
 }
 impl knob::StyleSheet for CustomStyleCircle {
-    fn active(&self) -> knob::Style {
-        knob::Style::Circle(Self::ACTIVE_CIRCLE_STYLE)
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> knob::Appearance {
+        knob::Appearance::Circle(Self::ACTIVE_CIRCLE_STYLE)
     }
 
-    fn hovered(&self) -> knob::Style {
-        knob::Style::Circle(knob::CircleStyle {
+    fn hovered(&self, _style: &Self::Style) -> knob::Appearance {
+        knob::Appearance::Circle(knob::CircleStyle {
             notch: knob::NotchShape::Circle(knob::CircleNotch {
                 color: colors::HANDLE_HOVER,
                 border_color: colors::FILLED_HOVER,
@@ -37,11 +39,14 @@ impl knob::StyleSheet for CustomStyleCircle {
         })
     }
 
-    fn dragging(&self) -> knob::Style {
-        self.hovered()
+    fn dragging(&self, style: &Self::Style) -> knob::Appearance {
+        self.hovered(style)
     }
 
-    fn value_arc_style(&self) -> Option<knob::ValueArcStyle> {
+    fn value_arc_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<knob::ValueArcStyle> {
         Some(knob::ValueArcStyle {
             width: 3.0,
             offset: 1.5,
@@ -52,7 +57,10 @@ impl knob::StyleSheet for CustomStyleCircle {
         })
     }
 
-    fn mod_range_arc_style(&self) -> Option<knob::ModRangeArcStyle> {
+    fn mod_range_arc_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<knob::ModRangeArcStyle> {
         Some(knob::ModRangeArcStyle {
             width: 3.0,
             offset: 6.0,
@@ -63,7 +71,10 @@ impl knob::StyleSheet for CustomStyleCircle {
         })
     }
 
-    fn text_marks_style(&self) -> Option<knob::TextMarksStyle> {
+    fn text_marks_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<knob::TextMarksStyle> {
         Some(knob::TextMarksStyle {
             style: text_marks::Style {
                 color: [0.16, 0.16, 0.16, 0.9].into(),
@@ -98,20 +109,24 @@ impl CustomStyleLine {
     };
 }
 impl knob::StyleSheet for CustomStyleLine {
-    fn active(&self) -> knob::Style {
-        knob::Style::Circle(Self::ACTIVE_CIRCLE_STYLE)
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> knob::Appearance {
+        knob::Appearance::Circle(Self::ACTIVE_CIRCLE_STYLE)
     }
 
-    #[allow(irrefutable_let_patterns)]
-    fn hovered(&self) -> knob::Style {
-        self.active()
+    fn hovered(&self, style: &Self::Style) -> knob::Appearance {
+        self.active(style)
     }
 
-    fn dragging(&self) -> knob::Style {
-        self.active()
+    fn dragging(&self, style: &Self::Style) -> knob::Appearance {
+        self.active(style)
     }
 
-    fn value_arc_style(&self) -> Option<knob::ValueArcStyle> {
+    fn value_arc_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<knob::ValueArcStyle> {
         Some(knob::ValueArcStyle {
             width: 2.5,
             offset: 2.0,
@@ -127,8 +142,10 @@ impl knob::StyleSheet for CustomStyleLine {
 
 pub struct CustomArc;
 impl knob::StyleSheet for CustomArc {
-    fn active(&self) -> knob::Style {
-        knob::Style::Arc(knob::ArcStyle {
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> knob::Appearance {
+        knob::Appearance::Arc(knob::ArcStyle {
             width: knob::StyleLength::Units(3.15),
             empty_color: colors::KNOB_ARC_EMPTY,
             filled_color: colors::KNOB_ARC,
@@ -143,19 +160,22 @@ impl knob::StyleSheet for CustomArc {
         })
     }
 
-    fn hovered(&self) -> knob::Style {
-        self.active()
+    fn hovered(&self, style: &Self::Style) -> knob::Appearance {
+        self.active(style)
     }
 
-    fn dragging(&self) -> knob::Style {
-        self.active()
+    fn dragging(&self, style: &Self::Style) -> knob::Appearance {
+        self.active(style)
     }
 
-    fn angle_range(&self) -> iced_audio::KnobAngleRange {
+    fn angle_range(&self, _style: &Self::Style) -> iced_audio::KnobAngleRange {
         iced_audio::KnobAngleRange::from_deg(40.0, 320.0)
     }
 
-    fn mod_range_arc_style(&self) -> Option<knob::ModRangeArcStyle> {
+    fn mod_range_arc_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<knob::ModRangeArcStyle> {
         Some(knob::ModRangeArcStyle {
             width: 3.0,
             offset: 1.5,
@@ -180,8 +200,10 @@ impl CustomArcBipolar {
     };
 }
 impl knob::StyleSheet for CustomArcBipolar {
-    fn active(&self) -> knob::Style {
-        knob::Style::ArcBipolar(knob::ArcBipolarStyle {
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> knob::Appearance {
+        knob::Appearance::ArcBipolar(knob::ArcBipolarStyle {
             width: knob::StyleLength::Units(3.15),
             empty_color: colors::KNOB_ARC_EMPTY,
             left_filled_color: colors::KNOB_ARC,
@@ -201,15 +223,15 @@ impl knob::StyleSheet for CustomArcBipolar {
         })
     }
 
-    fn hovered(&self) -> knob::Style {
-        self.active()
+    fn hovered(&self, style: &Self::Style) -> knob::Appearance {
+        self.active(style)
     }
 
-    fn dragging(&self) -> knob::Style {
-        self.active()
+    fn dragging(&self, style: &Self::Style) -> knob::Appearance {
+        self.active(style)
     }
 
-    fn angle_range(&self) -> iced_audio::KnobAngleRange {
+    fn angle_range(&self, _style: &Self::Style) -> iced_audio::KnobAngleRange {
         iced_audio::KnobAngleRange::from_deg(40.0, 320.0)
     }
 }

--- a/examples/inputs_tour/src/style/mod.rs
+++ b/examples/inputs_tour/src/style/mod.rs
@@ -1,6 +1,7 @@
 mod colors;
 
-pub mod button;
+// FIXME: style and theme has changed a lot in latest iced
+//pub mod button;
 pub mod h_slider;
 pub mod knob;
 pub mod mod_range_input;

--- a/examples/inputs_tour/src/style/mod.rs
+++ b/examples/inputs_tour/src/style/mod.rs
@@ -1,7 +1,8 @@
 mod colors;
 
-// FIXME: style and theme has changed a lot in latest iced
-//pub mod button;
+pub mod button;
+pub use button::Button;
+
 pub mod h_slider;
 pub mod knob;
 pub mod mod_range_input;

--- a/examples/inputs_tour/src/style/mod_range_input.rs
+++ b/examples/inputs_tour/src/style/mod_range_input.rs
@@ -15,18 +15,20 @@ impl CustomStyle {
         };
 }
 impl mod_range_input::StyleSheet for CustomStyle {
-    fn active(&self) -> mod_range_input::Style {
-        mod_range_input::Style::Circle(Self::ACTIVE_STYLE)
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> mod_range_input::Appearance {
+        mod_range_input::Appearance::Circle(Self::ACTIVE_STYLE)
     }
 
-    fn hovered(&self) -> mod_range_input::Style {
-        mod_range_input::Style::Circle(mod_range_input::CircleStyle {
+    fn hovered(&self, _style: &Self::Style) -> mod_range_input::Appearance {
+        mod_range_input::Appearance::Circle(mod_range_input::CircleStyle {
             border_width: 1.0,
             ..Self::ACTIVE_STYLE
         })
     }
 
-    fn dragging(&self) -> mod_range_input::Style {
-        self.hovered()
+    fn dragging(&self, style: &Self::Style) -> mod_range_input::Appearance {
+        self.hovered(style)
     }
 }

--- a/examples/inputs_tour/src/style/ramp.rs
+++ b/examples/inputs_tour/src/style/ramp.rs
@@ -7,7 +7,7 @@ use super::colors;
 
 pub struct CustomStyle;
 impl CustomStyle {
-    const ACTIVE_STYLE: ramp::Style = ramp::Style {
+    const ACTIVE_STYLE: ramp::Appearance = ramp::Appearance {
         back_color: colors::KNOB,
         back_border_width: 2.0,
         back_border_color: colors::KNOB_BORDER,
@@ -18,12 +18,14 @@ impl CustomStyle {
     };
 }
 impl ramp::StyleSheet for CustomStyle {
-    fn active(&self) -> ramp::Style {
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> ramp::Appearance {
         Self::ACTIVE_STYLE
     }
 
-    fn hovered(&self) -> ramp::Style {
-        ramp::Style {
+    fn hovered(&self, _style: &Self::Style) -> ramp::Appearance {
+        ramp::Appearance {
             line_center_color: Color::from_rgb(0.8, 0.8, 0.8),
             line_up_color: Color::from_rgb(0.0, 1.0, 0.0),
             line_down_color: Color::from_rgb(
@@ -35,7 +37,7 @@ impl ramp::StyleSheet for CustomStyle {
         }
     }
 
-    fn dragging(&self) -> ramp::Style {
-        self.hovered()
+    fn dragging(&self, style: &Self::Style) -> ramp::Appearance {
+        self.hovered(style)
     }
 }

--- a/examples/inputs_tour/src/style/v_slider.rs
+++ b/examples/inputs_tour/src/style/v_slider.rs
@@ -1,4 +1,5 @@
-use iced::{image, Color, Rectangle};
+use iced::widget::image;
+use iced::{Color, Rectangle};
 use iced_audio::{text_marks, tick_marks, v_slider, Offset};
 
 use super::colors;

--- a/examples/inputs_tour/src/style/v_slider.rs
+++ b/examples/inputs_tour/src/style/v_slider.rs
@@ -20,23 +20,28 @@ impl RectStyle {
     };
 }
 impl v_slider::StyleSheet for RectStyle {
-    fn active(&self) -> v_slider::Style {
-        v_slider::Style::Rect(Self::ACTIVE_RECT_STYLE)
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> v_slider::Appearance {
+        v_slider::Appearance::Rect(Self::ACTIVE_RECT_STYLE)
     }
 
-    fn hovered(&self) -> v_slider::Style {
-        v_slider::Style::Rect(v_slider::RectStyle {
+    fn hovered(&self, _style: &Self::Style) -> v_slider::Appearance {
+        v_slider::Appearance::Rect(v_slider::RectStyle {
             filled_color: colors::FILLED_HOVER,
             handle_height: 5,
             ..Self::ACTIVE_RECT_STYLE
         })
     }
 
-    fn dragging(&self) -> v_slider::Style {
-        self.hovered()
+    fn dragging(&self, style: &Self::Style) -> v_slider::Appearance {
+        self.hovered(style)
     }
 
-    fn mod_range_style(&self) -> Option<v_slider::ModRangeStyle> {
+    fn mod_range_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<v_slider::ModRangeStyle> {
         Some(v_slider::ModRangeStyle {
             placement: v_slider::ModRangePlacement::CenterFilled {
                 edge_padding: 0.0,
@@ -81,12 +86,14 @@ impl RectBipolarStyle {
         };
 }
 impl v_slider::StyleSheet for RectBipolarStyle {
-    fn active(&self) -> v_slider::Style {
-        v_slider::Style::RectBipolar(Self::ACTIVE_RECT_STYLE)
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> v_slider::Appearance {
+        v_slider::Appearance::RectBipolar(Self::ACTIVE_RECT_STYLE)
     }
 
-    fn hovered(&self) -> v_slider::Style {
-        v_slider::Style::RectBipolar(v_slider::RectBipolarStyle {
+    fn hovered(&self, _style: &Self::Style) -> v_slider::Appearance {
+        v_slider::Appearance::RectBipolar(v_slider::RectBipolarStyle {
             top_filled_color: colors::FILLED_HOVER,
             bottom_filled_color: Color::from_rgb(0.0, 0.64, 0.0),
             handle_height: 5,
@@ -94,8 +101,8 @@ impl v_slider::StyleSheet for RectBipolarStyle {
         })
     }
 
-    fn dragging(&self) -> v_slider::Style {
-        self.hovered()
+    fn dragging(&self, style: &Self::Style) -> v_slider::Appearance {
+        self.hovered(style)
     }
 }
 
@@ -103,8 +110,10 @@ impl v_slider::StyleSheet for RectBipolarStyle {
 
 pub struct TextureStyle(pub image::Handle, pub Rectangle);
 impl v_slider::StyleSheet for TextureStyle {
-    fn active(&self) -> v_slider::Style {
-        v_slider::Style::Texture(v_slider::TextureStyle {
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> v_slider::Appearance {
+        v_slider::Appearance::Texture(v_slider::TextureStyle {
             rail: v_slider::ClassicRail {
                 rail_colors: (
                     [0.0, 0.0, 0.0, 0.9].into(),
@@ -119,15 +128,18 @@ impl v_slider::StyleSheet for TextureStyle {
         })
     }
 
-    fn hovered(&self) -> v_slider::Style {
-        self.active()
+    fn hovered(&self, style: &Self::Style) -> v_slider::Appearance {
+        self.active(style)
     }
 
-    fn dragging(&self) -> v_slider::Style {
-        self.active()
+    fn dragging(&self, style: &Self::Style) -> v_slider::Appearance {
+        self.active(style)
     }
 
-    fn tick_marks_style(&self) -> Option<v_slider::TickMarksStyle> {
+    fn tick_marks_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<v_slider::TickMarksStyle> {
         Some(v_slider::TickMarksStyle {
             style: tick_marks::Style {
                 tier_1: tick_marks::Shape::Line {
@@ -154,7 +166,10 @@ impl v_slider::StyleSheet for TextureStyle {
         })
     }
 
-    fn text_marks_style(&self) -> Option<v_slider::TextMarksStyle> {
+    fn text_marks_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<v_slider::TextMarksStyle> {
         Some(v_slider::TextMarksStyle {
             style: text_marks::Style {
                 color: [0.16, 0.16, 0.16, 0.9].into(),

--- a/examples/inputs_tour/src/style/xy_pad.rs
+++ b/examples/inputs_tour/src/style/xy_pad.rs
@@ -14,7 +14,7 @@ impl CustomStyle {
         border_radius: 2.0,
         border_color: colors::HANDLE,
     };
-    const ACTIVE_STYLE: xy_pad::Style = xy_pad::Style {
+    const ACTIVE_STYLE: xy_pad::Appearance = xy_pad::Appearance {
         rail_width: 1.0,
         h_rail_color: colors::HANDLE,
         v_rail_color: colors::HANDLE,
@@ -32,12 +32,14 @@ impl CustomStyle {
     };
 }
 impl xy_pad::StyleSheet for CustomStyle {
-    fn active(&self) -> xy_pad::Style {
+    type Style = iced::Theme;
+
+    fn active(&self, _style: &Self::Style) -> xy_pad::Appearance {
         Self::ACTIVE_STYLE
     }
 
-    fn hovered(&self) -> xy_pad::Style {
-        xy_pad::Style {
+    fn hovered(&self, _style: &Self::Style) -> xy_pad::Appearance {
+        xy_pad::Appearance {
             handle: xy_pad::HandleShape::Square(xy_pad::HandleSquare {
                 color: colors::FILLED_HOVER,
                 size: 12,
@@ -47,8 +49,8 @@ impl xy_pad::StyleSheet for CustomStyle {
         }
     }
 
-    fn dragging(&self) -> xy_pad::Style {
-        xy_pad::Style {
+    fn dragging(&self, _style: &Self::Style) -> xy_pad::Appearance {
+        xy_pad::Appearance {
             handle: xy_pad::HandleShape::Square(xy_pad::HandleSquare {
                 color: colors::FILLED_HOVER,
                 ..Self::ACTIVE_HANDLE

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,5 +8,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { version = "0.5.2", features=["image"] }
+iced = { version = "0.5.2", default-features = false, features = ["image"] }
 iced_audio = { path = "../.." }
+
+[features]
+default = ["wgpu"]
+glow = ["iced_audio/glow"]
+wgpu = ["iced_audio/wgpu"]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { version = "0.4", features=["image"] }
-iced_audio = { path = "../../" }
+iced = { version = "0.5.2", features=["image"] }
+iced_audio = { path = "../.." }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -136,8 +136,7 @@ impl Sandbox for App {
             VSlider::new(self.v_slider_param, Message::VSliderDB)
                 .tick_marks(&self.center_tick_mark);
 
-        let knob_widget =
-            Knob::new(self.knob_param, Message::KnobFreq, || None, || None);
+        let knob_widget = Knob::new(self.knob_param, Message::KnobFreq);
 
         let xy_pad_widget = XYPad::new(
             self.xy_pad_x_param,

--- a/src/core/normal_param.rs
+++ b/src/core/normal_param.rs
@@ -32,3 +32,13 @@ impl Default for NormalParam {
         }
     }
 }
+
+impl NormalParam {
+    /// Updates the [`Normal`] value of this `NormalParam`
+    ///
+    /// [`Normal`]: ../struct.Normal.html
+    #[inline]
+    pub fn update(&mut self, normal: Normal) {
+        self.value = normal;
+    }
+}

--- a/src/core/offset.rs
+++ b/src/core/offset.rs
@@ -1,6 +1,6 @@
 //! Offset type
 
-use iced_native::Rectangle;
+use iced::{Point, Rectangle};
 
 /// A 2D offset vector with a horizontal and vertical offset in pixels.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -52,9 +52,9 @@ impl Default for Offset {
     }
 }
 
-impl From<Offset> for iced_graphics::Point {
+impl From<Offset> for Point {
     fn from(offset: Offset) -> Self {
-        iced_graphics::Point {
+        Point {
             x: offset.x,
             y: offset.y,
         }

--- a/src/graphics/h_slider.rs
+++ b/src/graphics/h_slider.rs
@@ -5,13 +5,12 @@
 use crate::core::{ModulationRange, Normal};
 use crate::graphics::{text_marks, tick_marks};
 use crate::native::h_slider;
-use iced::Renderer;
 use iced_graphics::Primitive;
 use iced_native::{Background, Color, Point, Rectangle};
 
 pub use crate::style::h_slider::{
-    ClassicHandle, ClassicRail, ClassicStyle, ModRangePlacement, ModRangeStyle,
-    RectBipolarStyle, RectStyle, Style, StyleSheet, TextMarksStyle,
+    Appearance, ClassicHandle, ClassicRail, ClassicStyle, ModRangePlacement,
+    ModRangeStyle, RectBipolarStyle, RectStyle, StyleSheet, TextMarksStyle,
     TextureStyle, TickMarksStyle,
 };
 
@@ -33,11 +32,12 @@ struct ValueMarkers<'a> {
 /// [`Param`]: ../../core/param/trait.Param.html
 /// [`HSlider`]: struct.HSlider.html
 pub type HSlider<'a, Message, Theme> =
-    h_slider::HSlider<'a, Message, Renderer<Theme>>;
+    h_slider::HSlider<'a, Message, iced::Renderer<Theme>>;
 
-impl<Theme> h_slider::Renderer for Renderer<Theme> {
-    type Style = Box<dyn StyleSheet>;
-
+impl h_slider::Renderer for iced::Renderer
+where
+    Self::Theme: StyleSheet,
+{
     fn draw(
         &mut self,
         bounds: Rectangle,
@@ -48,18 +48,21 @@ impl<Theme> h_slider::Renderer for Renderer<Theme> {
         mod_range_2: Option<&ModulationRange>,
         tick_marks: Option<&tick_marks::Group>,
         text_marks: Option<&text_marks::Group>,
-        style_sheet: &Self::Style,
+        style_sheet: &dyn StyleSheet<
+            Style = <Self::Theme as StyleSheet>::Style,
+        >,
+        style: &<Self::Theme as StyleSheet>::Style,
         tick_marks_cache: &tick_marks::PrimitiveCache,
         text_marks_cache: &text_marks::PrimitiveCache,
     ) {
         let is_mouse_over = bounds.contains(cursor_position);
 
-        let style = if is_dragging {
-            style_sheet.dragging()
+        let appearance = if is_dragging {
+            style_sheet.dragging(style)
         } else if is_mouse_over {
-            style_sheet.hovered()
+            style_sheet.hovered(style)
         } else {
-            style_sheet.active()
+            style_sheet.active(style)
         };
 
         let bounds = Rectangle {
@@ -74,14 +77,14 @@ impl<Theme> h_slider::Renderer for Renderer<Theme> {
             text_marks,
             mod_range_1,
             mod_range_2,
-            tick_marks_style: style_sheet.tick_marks_style(),
-            text_marks_style: style_sheet.text_marks_style(),
-            mod_range_style_1: style_sheet.mod_range_style(),
-            mod_range_style_2: style_sheet.mod_range_style_2(),
+            tick_marks_style: style_sheet.tick_marks_style(style),
+            text_marks_style: style_sheet.text_marks_style(style),
+            mod_range_style_1: style_sheet.mod_range_style(style),
+            mod_range_style_2: style_sheet.mod_range_style_2(style),
         };
 
-        let primitives = match style {
-            Style::Texture(style) => draw_texture_style(
+        let primitives = match appearance {
+            Appearance::Texture(style) => draw_texture_style(
                 normal,
                 &bounds,
                 style,
@@ -89,7 +92,7 @@ impl<Theme> h_slider::Renderer for Renderer<Theme> {
                 tick_marks_cache,
                 text_marks_cache,
             ),
-            Style::Classic(style) => draw_classic_style(
+            Appearance::Classic(style) => draw_classic_style(
                 normal,
                 &bounds,
                 &style,
@@ -97,7 +100,7 @@ impl<Theme> h_slider::Renderer for Renderer<Theme> {
                 tick_marks_cache,
                 text_marks_cache,
             ),
-            Style::Rect(style) => draw_rect_style(
+            Appearance::Rect(style) => draw_rect_style(
                 normal,
                 &bounds,
                 &style,
@@ -105,7 +108,7 @@ impl<Theme> h_slider::Renderer for Renderer<Theme> {
                 tick_marks_cache,
                 text_marks_cache,
             ),
-            Style::RectBipolar(style) => draw_rect_bipolar_style(
+            Appearance::RectBipolar(style) => draw_rect_bipolar_style(
                 normal,
                 &bounds,
                 &style,

--- a/src/graphics/h_slider.rs
+++ b/src/graphics/h_slider.rs
@@ -5,10 +5,10 @@
 use crate::core::{ModulationRange, Normal};
 use crate::graphics::{text_marks, tick_marks};
 use crate::native::h_slider;
-use iced_graphics::{Backend, Primitive, Renderer};
+use iced::Renderer;
+use iced_graphics::Primitive;
 use iced_native::{Background, Color, Point, Rectangle};
 
-pub use crate::native::h_slider::State;
 pub use crate::style::h_slider::{
     ClassicHandle, ClassicRail, ClassicStyle, ModRangePlacement, ModRangeStyle,
     RectBipolarStyle, RectStyle, Style, StyleSheet, TextMarksStyle,
@@ -32,10 +32,10 @@ struct ValueMarkers<'a> {
 ///
 /// [`Param`]: ../../core/param/trait.Param.html
 /// [`HSlider`]: struct.HSlider.html
-pub type HSlider<'a, Message, Backend> =
-    h_slider::HSlider<'a, Message, Renderer<Backend>>;
+pub type HSlider<'a, Message, Theme> =
+    h_slider::HSlider<'a, Message, Renderer<Theme>>;
 
-impl<B: Backend> h_slider::Renderer for Renderer<B> {
+impl<Theme> h_slider::Renderer for Renderer<Theme> {
     type Style = Box<dyn StyleSheet>;
 
     fn draw(

--- a/src/graphics/knob.rs
+++ b/src/graphics/knob.rs
@@ -7,11 +7,12 @@ use std::cmp::Ordering;
 use crate::core::{ModulationRange, Normal};
 use crate::graphics::{text_marks, tick_marks};
 use crate::native::knob;
-use iced_graphics::widget::canvas::{path::Arc, Frame, Path, Stroke};
-use iced_graphics::{Backend, Primitive, Renderer};
+use iced::widget::canvas::{path::Arc, Frame, Path, Stroke};
+use iced::Renderer;
+use iced_graphics::triangle;
+use iced_graphics::Primitive;
 use iced_native::{Background, Point, Rectangle, Size, Vector};
 
-pub use crate::native::knob::State;
 pub use crate::style::knob::{
     ArcBipolarStyle, ArcStyle, CircleNotch, CircleStyle, LineCap, LineNotch,
     ModRangeArcStyle, NotchShape, Style, StyleLength, StyleSheet,
@@ -43,10 +44,9 @@ struct KnobInfo {
 /// A rotating knob GUI widget that controls a [`Param`]
 ///
 /// [`Param`]: ../../core/param/struct.Param.html
-pub type Knob<'a, Message, Backend> =
-    knob::Knob<'a, Message, Renderer<Backend>>;
+pub type Knob<'a, Message, Theme> = knob::Knob<'a, Message, Renderer<Theme>>;
 
-impl<B: Backend> knob::Renderer for Renderer<B> {
+impl<Theme> knob::Renderer for Renderer<Theme> {
     type Style = Box<dyn StyleSheet>;
 
     fn draw(
@@ -274,7 +274,7 @@ fn draw_value_arc(
         if let Some(empty_color) = style.empty_color {
             let empty_stroke = Stroke {
                 width: style.width,
-                color: empty_color,
+                style: triangle::Style::Solid(empty_color),
                 line_cap: style.cap,
                 ..Stroke::default()
             };
@@ -301,7 +301,7 @@ fn draw_value_arc(
                 if knob_info.value < Normal::center() {
                     let filled_stroke = Stroke {
                         width: style.width,
-                        color: style.left_filled_color,
+                        style: triangle::Style::Solid(style.left_filled_color),
                         line_cap: style.cap,
                         ..Stroke::default()
                     };
@@ -319,7 +319,7 @@ fn draw_value_arc(
                 } else if knob_info.value > Normal::center() {
                     let filled_stroke = Stroke {
                         width: style.width,
-                        color: right_filled_color,
+                        style: triangle::Style::Solid(right_filled_color),
                         line_cap: style.cap,
                         ..Stroke::default()
                     };
@@ -339,7 +339,7 @@ fn draw_value_arc(
         } else if knob_info.value != Normal::min() {
             let filled_stroke = Stroke {
                 width: style.width,
-                color: style.left_filled_color,
+                style: triangle::Style::Solid(style.left_filled_color),
                 line_cap: style.cap,
                 ..Stroke::default()
             };
@@ -388,7 +388,7 @@ fn draw_mod_range_arc(
             if let Some(empty_color) = style.empty_color {
                 let empty_stroke = Stroke {
                     width: style.width,
-                    color: empty_color,
+                    style: triangle::Style::Solid(empty_color),
                     line_cap: style.cap,
                     ..Stroke::default()
                 };
@@ -423,7 +423,7 @@ fn draw_mod_range_arc(
 
                 let filled_stroke = Stroke {
                     width: style.width,
-                    color,
+                    style: triangle::Style::Solid(color),
                     line_cap: style.cap,
                     ..Stroke::default()
                 };
@@ -495,7 +495,7 @@ fn draw_line_notch(knob_info: &KnobInfo, style: &LineNotch) -> Primitive {
 
     let stroke = Stroke {
         width: style.width.from_knob_diameter(knob_info.bounds.width),
-        color: style.color,
+        style: triangle::Style::Solid(style.color),
         line_cap: style.cap,
         ..Stroke::default()
     };
@@ -599,7 +599,7 @@ fn draw_arc_style<'a>(
 
         let empty_stroke = Stroke {
             width,
-            color: style.empty_color,
+            style: triangle::Style::Solid(style.empty_color),
             line_cap: style.cap,
             ..Stroke::default()
         };
@@ -617,7 +617,7 @@ fn draw_arc_style<'a>(
 
         let filled_stroke = Stroke {
             width,
-            color: style.filled_color,
+            style: triangle::Style::Solid(style.filled_color),
             line_cap: style.cap,
             ..Stroke::default()
         };
@@ -711,7 +711,7 @@ fn draw_arc_bipolar_style<'a>(
 
         let empty_stroke = Stroke {
             width,
-            color: style.empty_color,
+            style: triangle::Style::Solid(style.empty_color),
             line_cap: style.cap,
             ..Stroke::default()
         };
@@ -737,7 +737,7 @@ fn draw_arc_bipolar_style<'a>(
             BipolarState::Left => {
                 let filled_stroke = Stroke {
                     width,
-                    color: style.left_filled_color,
+                    style: triangle::Style::Solid(style.left_filled_color),
                     line_cap: style.cap,
                     ..Stroke::default()
                 };
@@ -756,7 +756,7 @@ fn draw_arc_bipolar_style<'a>(
             BipolarState::Right => {
                 let filled_stroke = Stroke {
                     width,
-                    color: style.right_filled_color,
+                    style: triangle::Style::Solid(style.right_filled_color),
                     line_cap: style.cap,
                     ..Stroke::default()
                 };

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -4,11 +4,10 @@ pub mod h_slider;
 pub mod knob;
 pub mod mod_range_input;
 pub mod ramp;
-pub mod v_slider;
-pub mod xy_pad;
-
 pub mod text_marks;
 pub mod tick_marks;
+pub mod v_slider;
+pub mod xy_pad;
 
 //pub mod db_meter;
 //pub mod phase_meter;

--- a/src/graphics/mod_range_input.rs
+++ b/src/graphics/mod_range_input.rs
@@ -2,44 +2,43 @@
 //!
 //! [`Param`]: ../core/param/struct.Param.html
 
-use crate::native::mod_range_input;
-
-use iced::Renderer;
 use iced_graphics::Primitive;
 use iced_native::{Background, Point, Rectangle};
 
+use crate::native::mod_range_input;
 pub use crate::style::mod_range_input::{
-    CircleStyle, DefaultInvisible, SquareStyle, Style, StyleSheet,
+    Appearance, CircleStyle, SquareStyle, StyleSheet,
 };
 
 /// An interactive dot that controls an [`Param`]
 ///
 /// [`Param`]: ../core/param/struct.Param.html
 pub type ModRangeInput<'a, Message, Theme> =
-    mod_range_input::ModRangeInput<'a, Message, Renderer<Theme>>;
+    mod_range_input::ModRangeInput<'a, Message, iced::Renderer<Theme>>;
 
-impl<Theme> mod_range_input::Renderer for Renderer<Theme> {
-    type Style = Box<dyn StyleSheet>;
-
+impl mod_range_input::Renderer for iced::Renderer {
     fn draw(
         &mut self,
         bounds: Rectangle,
         cursor_position: Point,
         is_dragging: bool,
-        style_sheet: &Self::Style,
+        style_sheet: &dyn StyleSheet<
+            Style = <Self::Theme as StyleSheet>::Style,
+        >,
+        style: &<Self::Theme as StyleSheet>::Style,
     ) {
         let is_mouse_over = bounds.contains(cursor_position);
 
-        let style = if is_dragging {
-            style_sheet.dragging()
+        let appearance = if is_dragging {
+            style_sheet.dragging(style)
         } else if is_mouse_over {
-            style_sheet.hovered()
+            style_sheet.hovered(style)
         } else {
-            style_sheet.active()
+            style_sheet.active(style)
         };
 
-        let dot: Primitive = match style {
-            Style::Circle(style) => {
+        let dot: Primitive = match appearance {
+            Appearance::Circle(style) => {
                 let bounds_x = bounds.x.floor();
                 let bounds_y = bounds.y.floor();
                 let bounds_size = bounds.width.floor();
@@ -59,7 +58,7 @@ impl<Theme> mod_range_input::Renderer for Renderer<Theme> {
                     border_color: style.border_color,
                 }
             }
-            Style::Square(style) => {
+            Appearance::Square(style) => {
                 let bounds_x = bounds.x.floor();
                 let bounds_y = bounds.y.floor();
                 let bounds_size = bounds.width.floor();
@@ -77,7 +76,7 @@ impl<Theme> mod_range_input::Renderer for Renderer<Theme> {
                     border_color: style.border_color,
                 }
             }
-            Style::Invisible => Primitive::None,
+            Appearance::Invisible => Primitive::None,
         };
 
         self.draw_primitive(dot)

--- a/src/graphics/mod_range_input.rs
+++ b/src/graphics/mod_range_input.rs
@@ -4,10 +4,10 @@
 
 use crate::native::mod_range_input;
 
-use iced_graphics::{Backend, Primitive, Renderer};
+use iced::Renderer;
+use iced_graphics::Primitive;
 use iced_native::{Background, Point, Rectangle};
 
-pub use crate::native::mod_range_input::State;
 pub use crate::style::mod_range_input::{
     CircleStyle, DefaultInvisible, SquareStyle, Style, StyleSheet,
 };
@@ -15,10 +15,10 @@ pub use crate::style::mod_range_input::{
 /// An interactive dot that controls an [`Param`]
 ///
 /// [`Param`]: ../core/param/struct.Param.html
-pub type ModRangeInput<'a, Message, Backend> =
-    mod_range_input::ModRangeInput<'a, Message, Renderer<Backend>>;
+pub type ModRangeInput<'a, Message, Theme> =
+    mod_range_input::ModRangeInput<'a, Message, Renderer<Theme>>;
 
-impl<B: Backend> mod_range_input::Renderer for Renderer<B> {
+impl<Theme> mod_range_input::Renderer for Renderer<Theme> {
     type Style = Box<dyn StyleSheet>;
 
     fn draw(

--- a/src/graphics/ramp.rs
+++ b/src/graphics/ramp.rs
@@ -5,11 +5,13 @@
 
 use crate::core::Normal;
 use crate::native::ramp;
-use iced_graphics::widget::canvas::{Frame, LineCap, Path, Stroke};
-use iced_graphics::{Backend, Primitive, Renderer};
-use iced_native::{Background, Point, Rectangle, Size, Vector};
+use iced::widget::canvas::{Frame, LineCap, Path, Stroke};
+use iced::Renderer;
+use iced::{Background, Point, Rectangle, Size, Vector};
+use iced_graphics::triangle;
+use iced_graphics::Primitive;
 
-pub use crate::native::ramp::{RampDirection, State};
+pub use crate::native::ramp::RampDirection;
 pub use crate::style::ramp::{Style, StyleSheet};
 
 /// A ramp GUI widget that controls a [`Param`]. It is usually used to
@@ -17,10 +19,9 @@ pub use crate::style::ramp::{Style, StyleSheet};
 ///
 /// [`Param`]: ../../core/param/trait.Param.html
 /// [`Ramp`]: struct.Ramp.html
-pub type Ramp<'a, Message, Backend> =
-    ramp::Ramp<'a, Message, Renderer<Backend>>;
+pub type Ramp<Message, Theme> = ramp::Ramp<Message, Renderer<Theme>>;
 
-impl<B: Backend> ramp::Renderer for Renderer<B> {
+impl<Theme> ramp::Renderer for Renderer<Theme> {
     type Style = Box<dyn StyleSheet>;
 
     fn draw(
@@ -73,7 +74,9 @@ impl<B: Backend> ramp::Renderer for Renderer<B> {
                     if normal.as_f32() < 0.449 {
                         let stroke = Stroke {
                             width: style.line_width as f32,
-                            color: style.line_down_color,
+                            style: triangle::Style::Solid(
+                                style.line_down_color,
+                            ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };
@@ -106,7 +109,7 @@ impl<B: Backend> ramp::Renderer for Renderer<B> {
                     } else if normal.as_f32() > 0.501 {
                         let stroke = Stroke {
                             width: style.line_width as f32,
-                            color: style.line_up_color,
+                            style: triangle::Style::Solid(style.line_up_color),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };
@@ -142,7 +145,9 @@ impl<B: Backend> ramp::Renderer for Renderer<B> {
                     } else {
                         let stroke = Stroke {
                             width: style.line_width as f32,
-                            color: style.line_center_color,
+                            style: triangle::Style::Solid(
+                                style.line_center_color,
+                            ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };
@@ -178,7 +183,9 @@ impl<B: Backend> ramp::Renderer for Renderer<B> {
                     if normal.as_f32() < 0.449 {
                         let stroke = Stroke {
                             width: style.line_width as f32,
-                            color: style.line_down_color,
+                            style: triangle::Style::Solid(
+                                style.line_down_color,
+                            ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };
@@ -214,7 +221,7 @@ impl<B: Backend> ramp::Renderer for Renderer<B> {
                     } else if normal.as_f32() > 0.501 {
                         let stroke = Stroke {
                             width: style.line_width as f32,
-                            color: style.line_up_color,
+                            style: triangle::Style::Solid(style.line_up_color),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };
@@ -250,7 +257,9 @@ impl<B: Backend> ramp::Renderer for Renderer<B> {
                     } else {
                         let stroke = Stroke {
                             width: style.line_width as f32,
-                            color: style.line_center_color,
+                            style: triangle::Style::Solid(
+                                style.line_center_color,
+                            ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };

--- a/src/graphics/ramp.rs
+++ b/src/graphics/ramp.rs
@@ -6,41 +6,45 @@
 use crate::core::Normal;
 use crate::native::ramp;
 use iced::widget::canvas::{Frame, LineCap, Path, Stroke};
-use iced::Renderer;
 use iced::{Background, Point, Rectangle, Size, Vector};
 use iced_graphics::triangle;
 use iced_graphics::Primitive;
 
 pub use crate::native::ramp::RampDirection;
-pub use crate::style::ramp::{Style, StyleSheet};
+pub use crate::style::ramp::{Appearance, StyleSheet};
 
 /// A ramp GUI widget that controls a [`Param`]. It is usually used to
 /// represent the easing of a parameter between two points in time.
 ///
 /// [`Param`]: ../../core/param/trait.Param.html
 /// [`Ramp`]: struct.Ramp.html
-pub type Ramp<Message, Theme> = ramp::Ramp<Message, Renderer<Theme>>;
+pub type Ramp<'a, Message, Theme> =
+    ramp::Ramp<'a, Message, iced::Renderer<Theme>>;
 
-impl<Theme> ramp::Renderer for Renderer<Theme> {
-    type Style = Box<dyn StyleSheet>;
-
+impl ramp::Renderer for iced::Renderer
+where
+    Self::Theme: StyleSheet,
+{
     fn draw(
         &mut self,
         bounds: Rectangle,
         cursor_position: Point,
         normal: Normal,
         is_dragging: bool,
-        style_sheet: &Self::Style,
+        style_sheet: &dyn StyleSheet<
+            Style = <Self::Theme as StyleSheet>::Style,
+        >,
+        style: &<Self::Theme as StyleSheet>::Style,
         direction: RampDirection,
     ) {
         let is_mouse_over = bounds.contains(cursor_position);
 
-        let style = if is_dragging {
-            style_sheet.dragging()
+        let appearance = if is_dragging {
+            style_sheet.dragging(style)
         } else if is_mouse_over {
-            style_sheet.hovered()
+            style_sheet.hovered(style)
         } else {
-            style_sheet.active()
+            style_sheet.active(style)
         };
 
         let bounds_x = bounds.x.floor();
@@ -56,13 +60,13 @@ impl<Theme> ramp::Renderer for Renderer<Theme> {
                 width: bounds_width,
                 height: bounds_height,
             },
-            background: Background::Color(style.back_color),
+            background: Background::Color(appearance.back_color),
             border_radius: 0.0,
-            border_width: style.back_border_width,
-            border_color: style.back_border_color,
+            border_width: appearance.back_border_width,
+            border_color: appearance.back_border_color,
         };
 
-        let border_width = style.back_border_width as f32;
+        let border_width = appearance.back_border_width as f32;
         let twice_border_width = border_width * 2.0;
 
         let range_width = bounds_width - twice_border_width;
@@ -73,9 +77,9 @@ impl<Theme> ramp::Renderer for Renderer<Theme> {
                 let primitive = {
                     if normal.as_f32() < 0.449 {
                         let stroke = Stroke {
-                            width: style.line_width as f32,
+                            width: appearance.line_width as f32,
                             style: triangle::Style::Solid(
-                                style.line_down_color,
+                                appearance.line_down_color,
                             ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
@@ -108,8 +112,10 @@ impl<Theme> ramp::Renderer for Renderer<Theme> {
                         }
                     } else if normal.as_f32() > 0.501 {
                         let stroke = Stroke {
-                            width: style.line_width as f32,
-                            style: triangle::Style::Solid(style.line_up_color),
+                            width: appearance.line_width as f32,
+                            style: triangle::Style::Solid(
+                                appearance.line_up_color,
+                            ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };
@@ -144,9 +150,9 @@ impl<Theme> ramp::Renderer for Renderer<Theme> {
                         }
                     } else {
                         let stroke = Stroke {
-                            width: style.line_width as f32,
+                            width: appearance.line_width as f32,
                             style: triangle::Style::Solid(
-                                style.line_center_color,
+                                appearance.line_center_color,
                             ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
@@ -182,9 +188,9 @@ impl<Theme> ramp::Renderer for Renderer<Theme> {
                 let primitive = {
                     if normal.as_f32() < 0.449 {
                         let stroke = Stroke {
-                            width: style.line_width as f32,
+                            width: appearance.line_width as f32,
                             style: triangle::Style::Solid(
-                                style.line_down_color,
+                                appearance.line_down_color,
                             ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
@@ -220,8 +226,10 @@ impl<Theme> ramp::Renderer for Renderer<Theme> {
                         }
                     } else if normal.as_f32() > 0.501 {
                         let stroke = Stroke {
-                            width: style.line_width as f32,
-                            style: triangle::Style::Solid(style.line_up_color),
+                            width: appearance.line_width as f32,
+                            style: triangle::Style::Solid(
+                                appearance.line_up_color,
+                            ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()
                         };
@@ -256,9 +264,9 @@ impl<Theme> ramp::Renderer for Renderer<Theme> {
                         }
                     } else {
                         let stroke = Stroke {
-                            width: style.line_width as f32,
+                            width: appearance.line_width as f32,
                             style: triangle::Style::Solid(
-                                style.line_center_color,
+                                appearance.line_center_color,
                             ),
                             line_cap: LineCap::Square,
                             ..Stroke::default()

--- a/src/graphics/text_marks/horizontal.rs
+++ b/src/graphics/text_marks/horizontal.rs
@@ -2,9 +2,8 @@ use super::PrimitiveCache;
 use crate::native::text_marks;
 use crate::style::text_marks::{Align, Placement, Style};
 
-use iced_graphics::{
-    alignment::Horizontal, alignment::Vertical, Primitive, Rectangle,
-};
+use iced::{alignment::Horizontal, alignment::Vertical, Rectangle};
+use iced_graphics::Primitive;
 
 fn draw_aligned(
     primitives: &mut Vec<Primitive>,

--- a/src/graphics/text_marks/mod.rs
+++ b/src/graphics/text_marks/mod.rs
@@ -1,6 +1,7 @@
 //! Structs for constructing a group of text marks.
 
 use iced_native::{Point, Rectangle};
+
 use std::cell::RefCell;
 use std::sync::Arc;
 

--- a/src/graphics/text_marks/radial.rs
+++ b/src/graphics/text_marks/radial.rs
@@ -2,9 +2,8 @@ use super::PrimitiveCache;
 use crate::native::text_marks;
 use crate::style::text_marks::Style;
 
-use iced_graphics::{
-    alignment::Horizontal, alignment::Vertical, Point, Primitive, Rectangle,
-};
+use iced::{alignment::Horizontal, alignment::Vertical, Point, Rectangle};
+use iced_graphics::Primitive;
 
 /// Draws text marks around an arc.
 ///

--- a/src/graphics/text_marks/vertical.rs
+++ b/src/graphics/text_marks/vertical.rs
@@ -2,9 +2,8 @@ use super::PrimitiveCache;
 use crate::native::text_marks;
 use crate::style::text_marks::{Align, Placement, Style};
 
-use iced_graphics::{
-    alignment::Horizontal, alignment::Vertical, Primitive, Rectangle,
-};
+use iced::{alignment::Horizontal, alignment::Vertical, Rectangle};
+use iced_graphics::Primitive;
 
 fn draw_aligned(
     primitives: &mut Vec<Primitive>,

--- a/src/graphics/tick_marks/radial.rs
+++ b/src/graphics/tick_marks/radial.rs
@@ -1,4 +1,5 @@
-use iced_graphics::widget::canvas::{Fill, Frame, LineCap, Path, Stroke};
+use iced::widget::canvas::{Fill, Frame, LineCap, Path, Stroke};
+use iced_graphics::triangle;
 use iced_graphics::Primitive;
 use iced_native::{Color, Point, Size, Vector};
 
@@ -17,11 +18,6 @@ fn draw_radial_circles(
     radius: f32,
     inverse: bool,
 ) {
-    let fill = Fill {
-        color,
-        ..Fill::default()
-    };
-
     let path = Path::circle(Point::new(0.0, -offset_radius), radius);
 
     if inverse {
@@ -33,7 +29,13 @@ fn draw_radial_circles(
                     frame.rotate(angle);
                 }
 
-                frame.fill(&path, fill);
+                frame.fill(
+                    &path,
+                    Fill {
+                        style: triangle::Style::Solid(color),
+                        ..Fill::default()
+                    },
+                );
             });
         }
     } else {
@@ -45,7 +47,13 @@ fn draw_radial_circles(
                     frame.rotate(angle);
                 }
 
-                frame.fill(&path, fill);
+                frame.fill(
+                    &path,
+                    Fill {
+                        style: triangle::Style::Solid(color),
+                        ..Fill::default()
+                    },
+                );
             });
         }
     }
@@ -62,13 +70,6 @@ fn draw_radial_lines(
     length: f32,
     inverse: bool,
 ) {
-    let stroke = Stroke {
-        width,
-        color,
-        line_cap: LineCap::Butt,
-        ..Stroke::default()
-    };
-
     let path = Path::line(
         Point::new(0.0, -offset_radius),
         Point::new(0.0, -offset_radius - length),
@@ -83,7 +84,15 @@ fn draw_radial_lines(
                     frame.rotate(angle);
                 }
 
-                frame.stroke(&path, stroke);
+                frame.stroke(
+                    &path,
+                    Stroke {
+                        width,
+                        style: triangle::Style::Solid(color),
+                        line_cap: LineCap::Butt,
+                        ..Stroke::default()
+                    },
+                );
             });
         }
     } else {
@@ -95,7 +104,15 @@ fn draw_radial_lines(
                     frame.rotate(angle);
                 }
 
-                frame.stroke(&path, stroke);
+                frame.stroke(
+                    &path,
+                    Stroke {
+                        width,
+                        style: triangle::Style::Solid(color),
+                        line_cap: LineCap::Butt,
+                        ..Stroke::default()
+                    },
+                );
             });
         }
     }

--- a/src/graphics/tick_marks/vertical.rs
+++ b/src/graphics/tick_marks/vertical.rs
@@ -1,10 +1,11 @@
-//! `iced_graphics` renderer for tick marks
+//! `iced` renderer for tick marks
 
 use super::PrimitiveCache;
 use crate::core::Normal;
 use crate::native::tick_marks;
 use crate::style::tick_marks::{Placement, Shape, Style};
-use iced_graphics::{Background, Color, Primitive, Rectangle};
+use iced::{Background, Color, Rectangle};
+use iced_graphics::Primitive;
 
 fn draw_vertical_lines(
     primitives: &mut Vec<Primitive>,

--- a/src/graphics/v_slider.rs
+++ b/src/graphics/v_slider.rs
@@ -5,10 +5,10 @@
 use crate::core::{ModulationRange, Normal};
 use crate::graphics::{text_marks, tick_marks};
 use crate::native::v_slider;
-use iced_graphics::{Backend, Primitive, Renderer};
+use iced::Renderer;
+use iced_graphics::Primitive;
 use iced_native::{Background, Color, Point, Rectangle};
 
-pub use crate::native::v_slider::State;
 pub use crate::style::v_slider::{
     ClassicHandle, ClassicRail, ClassicStyle, ModRangePlacement, ModRangeStyle,
     RectBipolarStyle, RectStyle, Style, StyleSheet, TextMarksStyle,
@@ -32,10 +32,10 @@ struct ValueMarkers<'a> {
 ///
 /// [`Param`]: ../../core/param/trait.Param.html
 /// [`VSlider`]: struct.VSlider.html
-pub type VSlider<'a, Message, Backend> =
-    v_slider::VSlider<'a, Message, Renderer<Backend>>;
+pub type VSlider<'a, Message, Theme> =
+    v_slider::VSlider<'a, Message, Renderer<Theme>>;
 
-impl<B: Backend> v_slider::Renderer for Renderer<B> {
+impl<Theme> v_slider::Renderer for Renderer<Theme> {
     type Style = Box<dyn StyleSheet>;
 
     fn draw(

--- a/src/graphics/xy_pad.rs
+++ b/src/graphics/xy_pad.rs
@@ -5,10 +5,10 @@
 
 use crate::core::Normal;
 use crate::native::xy_pad;
-use iced_graphics::{Backend, Primitive, Renderer};
+use iced::Renderer;
+use iced_graphics::Primitive;
 use iced_native::{Background, Color, Point, Rectangle};
 
-pub use crate::native::xy_pad::State;
 pub use crate::style::xy_pad::{
     HandleCircle, HandleShape, HandleSquare, Style, StyleSheet,
 };
@@ -21,10 +21,10 @@ pub use crate::style::xy_pad::{
 ///
 /// [`Param`]: ../../core/param/trait.Param.html
 /// [`XYPad`]: struct.XYPad.html
-pub type XYPad<'a, Message, Backend> =
-    xy_pad::XYPad<'a, Message, Renderer<Backend>>;
+pub type XYPad<'a, Message, Theme> =
+    xy_pad::XYPad<'a, Message, Renderer<Theme>>;
 
-impl<B: Backend> xy_pad::Renderer for Renderer<B> {
+impl<Theme> xy_pad::Renderer for Renderer<Theme> {
     type Style = Box<dyn StyleSheet>;
 
     fn draw(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,11 +194,17 @@
 //! [`Iced`]: https://github.com/hecrj/iced
 //! [`here`]: https://github.com/hecrj/iced
 
-#![deny(missing_docs)]
-#![deny(missing_debug_implementations)]
-#![deny(unused_results)]
-#![forbid(rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(
+    unused_results,
+    clippy::extra_unused_lifetimes,
+    clippy::from_over_into,
+    clippy::needless_borrow,
+    clippy::new_without_default,
+    clippy::useless_conversion
+)]
+#![deny(missing_docs, unused_results)]
+#![forbid(unsafe_code, rust_2018_idioms)]
+#![allow(clippy::inherent_to_string, clippy::type_complexity)]
 
 //extern crate simdeez;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```toml
 //! iced_audio = { git = "https://github.com/BillyDM/iced_audio", branch = "iced_git" }
 //! ```
-//! __Both Iced Audio and [Iced] move fast and the `main` and `iced_git` branch can contain breaking changes!__ If
+//! __Both Iced Audio and [`Iced`] move fast and the `main` and `iced_git` branch can contain breaking changes!__ If
 //! you want to learn about a specific release, check out [the release list].
 //!
 //! # Simple Usage Example
@@ -21,13 +21,12 @@
 //!
 //! ```no_run
 // Import iced modules.
-//! use iced::{
-//!     Align, Column, Container, Element, Length, Sandbox, Settings, Text,
-//! };
+//! use iced::widget::{column, container, text};
+//! use iced::{Alignment, Element, Length, Sandbox, Settings};
 //! // Import iced_audio modules.
 //! use iced_audio::{
-//!     h_slider, knob, tick_marks, v_slider, xy_pad, FloatRange, FreqRange,
-//!     HSlider, IntRange, Knob, LogDBRange, Normal, VSlider, XYPad,
+//!     tick_marks, FloatRange, FreqRange, HSlider, IntRange, Knob, LogDBRange,
+//!     Normal, NormalParam, VSlider, XYPad,
 //! };
 //!
 //! // The message when a parameter widget is moved by the user
@@ -62,11 +61,12 @@
 //!     db_range: LogDBRange,
 //!     freq_range: FreqRange,
 //!
-//!     // The states of the widgets that will control the parameters.
-//!     h_slider_state: h_slider::State,
-//!     v_slider_state: v_slider::State,
-//!     knob_state: knob::State,
-//!     xy_pad_state: xy_pad::State,
+//!     // The parameters of the widgets.
+//!     h_slider_param: NormalParam,
+//!     v_slider_param: NormalParam,
+//!     knob_param: NormalParam,
+//!     xy_pad_x_param: NormalParam,
+//!     xy_pad_y_param: NormalParam,
 //!
 //!     // A group of tick marks with their size and position.
 //!     center_tick_mark: tick_marks::Group,
@@ -93,17 +93,11 @@
 //!
 //!             // Initialize the state of the widgets with a normalized parameter
 //!             // that has a value and a default value.
-//!             h_slider_state: h_slider::State::new(int_range.normal_param(5, 5)),
-//!             v_slider_state: v_slider::State::new(
-//!                 db_range.default_normal_param(),
-//!             ),
-//!             knob_state: knob::State::new(
-//!                 freq_range.normal_param(1000.0, 1000.0),
-//!             ),
-//!             xy_pad_state: xy_pad::State::new(
-//!                 float_range.default_normal_param(),
-//!                 float_range.default_normal_param(),
-//!             ),
+//!             h_slider_param: int_range.normal_param(5, 5),
+//!             v_slider_param: db_range.default_normal_param(),
+//!             knob_param: freq_range.normal_param(1000.0, 1000.0),
+//!             xy_pad_x_param: float_range.default_normal_param(),
+//!             xy_pad_y_param: float_range.default_normal_param(),
 //!
 //!             // Add a tick mark at the center position with the tier 2 size
 //!             center_tick_mark: tick_marks::Group::center(tick_marks::Tier::Two),
@@ -124,20 +118,27 @@
 //!             // Now do something useful with that value!
 //!             Message::HSliderInt(normal) => {
 //!                 // Integer parameters must be snapped to make the widget "step" when moved.
-//!                 self.h_slider_state.snap_visible_to(&self.int_range);
+//!                 self.h_slider_param.update(self.int_range.snapped(normal));
 //!
 //!                 let value = self.int_range.unmap_to_value(normal);
 //!                 self.output_text = format!("HSliderInt: {}", value);
 //!             }
 //!             Message::VSliderDB(normal) => {
+//!                 self.v_slider_param.update(normal);
+//!
 //!                 let value = self.db_range.unmap_to_value(normal);
 //!                 self.output_text = format!("VSliderDB: {:.3}", value);
 //!             }
 //!             Message::KnobFreq(normal) => {
+//!                 self.knob_param.update(normal);
+//!
 //!                 let value = self.freq_range.unmap_to_value(normal);
 //!                 self.output_text = format!("KnobFreq: {:.2}", value);
 //!             }
 //!             Message::XYPadFloat(normal_x, normal_y) => {
+//!                 self.xy_pad_x_param.update(normal_x);
+//!                 self.xy_pad_y_param.update(normal_y);
+//!
 //!                 let value_x = self.float_range.unmap_to_value(normal_x);
 //!                 let value_y = self.float_range.unmap_to_value(normal_y);
 //!                 self.output_text =
@@ -146,40 +147,41 @@
 //!         }
 //!     }
 //!
-//!     fn view(&mut self) -> Element<Message> {
+//!     fn view(&self) -> Element<Message> {
 //!         // Create each parameter widget, passing in the current state of the widget.
 //!         let h_slider_widget =
-//!             HSlider::new(&mut self.h_slider_state, Message::HSliderInt)
+//!             HSlider::new(self.h_slider_param, Message::HSliderInt)
 //!                 // Add the tick mark group to this widget.
 //!                 .tick_marks(&self.center_tick_mark);
 //!
 //!         let v_slider_widget =
-//!             VSlider::new(&mut self.v_slider_state, Message::VSliderDB)
+//!             VSlider::new(self.v_slider_param, Message::VSliderDB)
 //!                 .tick_marks(&self.center_tick_mark);
 //!
-//!         let knob_widget = Knob::new(&mut self.knob_state, Message::KnobFreq);
+//!         let knob_widget =
+//!             Knob::new(self.knob_param, Message::KnobFreq);
 //!
-//!         let xy_pad_widget =
-//!             XYPad::new(&mut self.xy_pad_state, Message::XYPadFloat);
+//!         let xy_pad_widget = XYPad::new(
+//!             self.xy_pad_x_param,
+//!             self.xy_pad_y_param,
+//!             Message::XYPadFloat
+//!         );
 //!
 //!         // Push the widgets into the iced DOM
-//!         let content: Element<_> = Column::new()
-//!             .max_width(300)
-//!             .max_height(500)
-//!             .spacing(20)
-//!             .padding(20)
-//!             .align_items(Align::Center)
-//!             .push(h_slider_widget)
-//!             .push(v_slider_widget)
-//!             .push(knob_widget)
-//!             .push(xy_pad_widget)
-//!             .push(
-//!                 Container::new(Text::new(&self.output_text))
-//!                     .width(Length::Fill),
-//!             )
-//!             .into();
+//!         let content = column![
+//!             h_slider_widget,
+//!             v_slider_widget,
+//!             knob_widget,
+//!             xy_pad_widget,
+//!             container(text(&self.output_text)).width(Length::Fill),
+//!         ]
+//!         .max_width(300)
+//!         .spacing(20)
+//!         .padding(20)
+//!         .align_items(Align::Center);
 //!
-//!         Container::new(content)
+//!         container(content)
+//!             .max_height(500)
 //!             .width(Length::Fill)
 //!             .height(Length::Fill)
 //!             .center_x()

--- a/src/native/h_slider.rs
+++ b/src/native/h_slider.rs
@@ -4,16 +4,14 @@
 
 use std::fmt::Debug;
 
+use iced_native::widget::tree::{self, Tree};
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
-    Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, touch, Clipboard, Element, Event, Layout,
+    Length, Point, Rectangle, Shell, Size, Widget,
 };
 
+use crate::core::{ModulationRange, Normal, NormalParam};
 use crate::native::{text_marks, tick_marks};
-use crate::{
-    core::{ModulationRange, Normal, NormalParam},
-    IntRange,
-};
 
 static DEFAULT_HEIGHT: u16 = 14;
 static DEFAULT_SCALAR: f32 = 0.9575;
@@ -28,8 +26,8 @@ static DEFAULT_MODIFIER_SCALAR: f32 = 0.02;
 /// [`HSlider`]: struct.HSlider.html
 #[allow(missing_debug_implementations)]
 pub struct HSlider<'a, Message, Renderer: self::Renderer> {
-    state: &'a mut State,
-    on_change: Box<dyn Fn(Normal) -> Message>,
+    normal_param: NormalParam,
+    on_change: Box<dyn Fn(Normal) -> Message + 'a>,
     scalar: f32,
     wheel_scalar: f32,
     modifier_scalar: f32,
@@ -43,21 +41,25 @@ pub struct HSlider<'a, Message, Renderer: self::Renderer> {
     mod_range_2: Option<&'a ModulationRange>,
 }
 
-impl<'a, Message, Renderer: self::Renderer> HSlider<'a, Message, Renderer> {
+impl<'a, Message, Renderer> HSlider<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
     /// Creates a new [`HSlider`].
     ///
     /// It expects:
-    ///   * the local [`State`] of the [`HSlider`]
+    ///   * the [`NormalParam`] of the [`HSlider`]
     ///   * a function that will be called when the [`HSlider`] is dragged.
     ///
-    /// [`State`]: struct.State.html
+    /// [`NormalParam`]: struct.NormalParam.html
     /// [`HSlider`]: struct.HSlider.html
-    pub fn new<F>(state: &'a mut State, on_change: F) -> Self
+    pub fn new<F>(normal_param: NormalParam, on_change: F) -> Self
     where
-        F: 'static + Fn(Normal) -> Message,
+        F: 'a + Fn(Normal) -> Message,
     {
         HSlider {
-            state,
+            normal_param,
             on_change: Box::new(on_change),
             scalar: DEFAULT_SCALAR,
             wheel_scalar: DEFAULT_WHEEL_SCALAR,
@@ -196,26 +198,19 @@ impl<'a, Message, Renderer: self::Renderer> HSlider<'a, Message, Renderer> {
 
     fn move_virtual_slider(
         &mut self,
-        messages: &mut Shell<'_, Message>,
+        state: &mut State,
+        shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
     ) {
-        if self.state.pressed_modifiers.contains(self.modifier_keys) {
+        if state.pressed_modifiers.contains(self.modifier_keys) {
             normal_delta *= self.modifier_scalar;
         }
 
-        let mut normal = self.state.continuous_normal - normal_delta;
+        self.normal_param.value =
+            (state.continuous_normal - normal_delta).into();
+        state.continuous_normal = self.normal_param.value.as_f32();
 
-        if normal < 0.0 {
-            normal = 0.0;
-        } else if normal > 1.0 {
-            normal = 1.0;
-        }
-
-        self.state.continuous_normal = normal;
-
-        self.state.normal_param.value = normal.into();
-
-        messages.publish((self.on_change)(self.state.normal_param.value));
+        shell.publish((self.on_change)(self.normal_param.value));
     }
 }
 
@@ -223,8 +218,7 @@ impl<'a, Message, Renderer: self::Renderer> HSlider<'a, Message, Renderer> {
 ///
 /// [`HSlider`]: struct.HSlider.html
 #[derive(Debug, Clone)]
-pub struct State {
-    normal_param: NormalParam,
+struct State {
     is_dragging: bool,
     prev_drag_x: f32,
     continuous_normal: f32,
@@ -238,75 +232,37 @@ impl State {
     /// Creates a new [`HSlider`] state.
     ///
     /// It expects:
-    /// * a [`NormalParam`] to assign to this widget
+    /// * current [`Normal`] value for the [`HSlider`]
     ///
-    /// [`NormalParam`]: ../../core/normal_param/struct.Param.html
+    /// [`Normal`]: ../../core/normal/struct.Normal.html
     /// [`HSlider`]: struct.HSlider.html
-    pub fn new(normal_param: NormalParam) -> Self {
+    fn new(normal: Normal) -> Self {
         Self {
-            normal_param,
             is_dragging: false,
             prev_drag_x: 0.0,
-            continuous_normal: normal_param.value.as_f32(),
+            continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
             tick_marks_cache: Default::default(),
             text_marks_cache: Default::default(),
         }
     }
-
-    /// Set the normalized value of the [`HSlider`].
-    pub fn set_normal(&mut self, normal: Normal) {
-        self.normal_param.value = normal;
-        self.continuous_normal = normal.into();
-    }
-
-    /// Get the normalized value of the [`HSlider`].
-    pub fn normal(&self) -> Normal {
-        self.normal_param.value
-    }
-
-    /// Set the normalized default value of the [`HSlider`].
-    pub fn set_default(&mut self, normal: Normal) {
-        self.normal_param.default = normal;
-    }
-
-    /// Get the normalized default value of the [`HSlider`].
-    pub fn default(&self) -> Normal {
-        self.normal_param.default
-    }
-
-    /// Snap the visible value of the [`HSlider`] to the nearest value
-    /// in the integer range.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use iced_audio::{h_slider, IntRange};
-    ///
-    /// let mut state = h_slider::State::new(Default::default());
-    /// let int_range = IntRange::new(0, 10);
-    ///
-    /// state.snap_visible_to(&int_range);
-    ///
-    /// ```
-    pub fn snap_visible_to(&mut self, range: &IntRange) {
-        self.normal_param.value = range.snapped(self.normal_param.value);
-    }
-
-    /// Is the [`HSlider`] currently in the dragging state?
-    ///
-    /// [`HSlider`]: struct.HSlider.html
-    pub fn is_dragging(&self) -> bool {
-        self.is_dragging
-    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for HSlider<'a, Message, Renderer>
 where
+    Message: Clone,
     Renderer: self::Renderer,
 {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::new(self.normal_param.value))
+    }
+
     fn width(&self) -> Length {
         Length::Shrink
     }
@@ -329,118 +285,121 @@ where
 
     fn on_event(
         &mut self,
+        state: &mut Tree,
         event: Event,
         layout: Layout<'_>,
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Shell<'_, Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
+        let state = state.state.downcast_mut::<State>();
+
         match event {
-            Event::Mouse(mouse_event) => match mouse_event {
-                mouse::Event::CursorMoved { .. } => {
-                    if self.state.is_dragging {
-                        let bounds_width = layout.bounds().width;
+            Event::Mouse(mouse::Event::CursorMoved { .. })
+            | Event::Touch(touch::Event::FingerMoved { .. }) => {
+                if state.is_dragging {
+                    let bounds_width = layout.bounds().width;
+                    if bounds_width > 0.0 {
+                        let normal_delta = (cursor_position.x
+                            - state.prev_drag_x)
+                            / bounds_width
+                            * -self.scalar;
 
-                        if bounds_width > 0.0 {
-                            let normal_delta = (cursor_position.x
-                                - self.state.prev_drag_x)
-                                / bounds_width
-                                * -self.scalar;
+                        state.prev_drag_x = cursor_position.x;
 
-                            self.state.prev_drag_x = cursor_position.x;
-
-                            self.move_virtual_slider(messages, normal_delta);
-
-                            return event::Status::Captured;
-                        }
-                    }
-                }
-                mouse::Event::WheelScrolled { delta } => {
-                    if self.wheel_scalar == 0.0 {
-                        return event::Status::Ignored;
-                    }
-
-                    if layout.bounds().contains(cursor_position) {
-                        let lines = match delta {
-                            iced_native::mouse::ScrollDelta::Lines {
-                                y,
-                                ..
-                            } => y,
-                            iced_native::mouse::ScrollDelta::Pixels {
-                                y,
-                                ..
-                            } => {
-                                if y > 0.0 {
-                                    1.0
-                                } else if y < 0.0 {
-                                    -1.0
-                                } else {
-                                    0.0
-                                }
-                            }
-                        };
-
-                        if lines != 0.0 {
-                            let normal_delta = -lines * self.wheel_scalar;
-
-                            self.move_virtual_slider(messages, normal_delta);
-
-                            return event::Status::Captured;
-                        }
-                    }
-                }
-                mouse::Event::ButtonPressed(mouse::Button::Left) => {
-                    if layout.bounds().contains(cursor_position) {
-                        let click = mouse::Click::new(
-                            cursor_position,
-                            self.state.last_click,
-                        );
-
-                        match click.kind() {
-                            mouse::click::Kind::Single => {
-                                self.state.is_dragging = true;
-                                self.state.prev_drag_x = cursor_position.x;
-                            }
-                            _ => {
-                                self.state.is_dragging = false;
-
-                                self.state.normal_param.value =
-                                    self.state.normal_param.default;
-
-                                messages.publish((self.on_change)(
-                                    self.state.normal_param.value,
-                                ));
-                            }
-                        }
-
-                        self.state.last_click = Some(click);
+                        self.move_virtual_slider(state, shell, normal_delta);
 
                         return event::Status::Captured;
                     }
                 }
-                mouse::Event::ButtonReleased(mouse::Button::Left) => {
-                    self.state.is_dragging = false;
-                    self.state.continuous_normal =
-                        self.state.normal_param.value.as_f32();
+            }
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if self.wheel_scalar == 0.0 {
+                    return event::Status::Ignored;
+                }
+
+                if layout.bounds().contains(cursor_position) {
+                    let lines = match delta {
+                        iced_native::mouse::ScrollDelta::Lines {
+                            y, ..
+                        } => y,
+                        iced_native::mouse::ScrollDelta::Pixels {
+                            y, ..
+                        } => {
+                            if y > 0.0 {
+                                1.0
+                            } else if y < 0.0 {
+                                -1.0
+                            } else {
+                                0.0
+                            }
+                        }
+                    };
+
+                    if lines != 0.0 {
+                        let normal_delta = -lines * self.wheel_scalar;
+
+                        self.move_virtual_slider(state, shell, normal_delta);
+
+                        return event::Status::Captured;
+                    }
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if layout.bounds().contains(cursor_position) {
+                    let click =
+                        mouse::Click::new(cursor_position, state.last_click);
+
+                    match click.kind() {
+                        mouse::click::Kind::Single => {
+                            state.is_dragging = true;
+                            state.prev_drag_x = cursor_position.x;
+                            state.continuous_normal =
+                                self.normal_param.value.as_f32();
+                        }
+                        _ => {
+                            state.is_dragging = false;
+
+                            self.normal_param.value = self.normal_param.default;
+                            state.continuous_normal =
+                                self.normal_param.default.as_f32();
+
+                            shell.publish((self.on_change)(
+                                self.normal_param.value,
+                            ));
+                        }
+                    }
+
+                    state.last_click = Some(click);
 
                     return event::Status::Captured;
                 }
-                _ => {}
-            },
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. })
+            | Event::Touch(touch::Event::FingerLost { .. }) => {
+                if state.is_dragging {
+                    state.is_dragging = false;
+                    state.continuous_normal = self.normal_param.value.as_f32();
+
+                    return event::Status::Captured;
+                }
+            }
             Event::Keyboard(keyboard_event) => match keyboard_event {
                 keyboard::Event::KeyPressed { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::KeyReleased { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::ModifiersChanged(modifiers) => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
@@ -454,24 +413,27 @@ where
 
     fn draw(
         &self,
+        state: &Tree,
         renderer: &mut Renderer,
+        _theme: &Renderer::Theme,
         _style: &iced_native::renderer::Style,
         layout: Layout<'_>,
         cursor_position: Point,
         _viewport: &Rectangle,
     ) {
+        let state = state.state.downcast_ref::<State>();
         renderer.draw(
             layout.bounds(),
             cursor_position,
-            self.state.normal_param.value,
-            self.state.is_dragging,
+            self.normal_param.value,
+            state.is_dragging,
             self.mod_range_1,
             self.mod_range_2,
             self.tick_marks,
             self.text_marks,
             &self.style,
-            &self.state.tick_marks_cache,
-            &self.state.text_marks_cache,
+            &state.tick_marks_cache,
+            &state.text_marks_cache,
         )
     }
 }
@@ -518,8 +480,8 @@ pub trait Renderer: iced_native::Renderer {
 impl<'a, Message, Renderer> From<HSlider<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
+    Message: 'a + Clone,
     Renderer: 'a + self::Renderer,
-    Message: 'a,
 {
     fn from(
         h_slider: HSlider<'a, Message, Renderer>,

--- a/src/native/knob.rs
+++ b/src/native/knob.rs
@@ -211,6 +211,10 @@ where
         shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
     ) {
+        if normal_delta.abs() < f32::EPSILON {
+            return;
+        }
+
         if state.pressed_modifiers.contains(self.modifier_keys) {
             normal_delta *= self.modifier_scalar;
         }

--- a/src/native/knob.rs
+++ b/src/native/knob.rs
@@ -4,14 +4,14 @@
 
 use std::fmt::Debug;
 
+use iced_native::widget::tree::{self, Tree};
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
-    Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, touch, Clipboard, Element, Event, Layout,
+    Length, Point, Rectangle, Shell, Size, Widget,
 };
 
 use crate::core::{ModulationRange, Normal, NormalParam};
 use crate::native::{text_marks, tick_marks};
-use crate::IntRange;
 
 static DEFAULT_SIZE: u16 = 30;
 static DEFAULT_SCALAR: f32 = 0.00385;
@@ -23,11 +23,11 @@ static DEFAULT_MODIFIER_SCALAR: f32 = 0.02;
 /// [`NormalParam`]: ../../core/normal_param/struct.NormalParam.html
 #[allow(missing_debug_implementations)]
 pub struct Knob<'a, Message, Renderer: self::Renderer> {
-    state: &'a mut State,
+    normal_param: NormalParam,
     size: Length,
-    on_change: Box<dyn Fn(Normal) -> Message>,
-    on_drag_start: Box<dyn Fn() -> Option<Message>>,
-    on_drag_end: Box<dyn Fn() -> Option<Message>>,
+    on_change: Box<dyn Fn(Normal) -> Message + 'a>,
+    on_drag_start: Box<dyn Fn() -> Option<Message> + 'a>,
+    on_drag_end: Box<dyn Fn() -> Option<Message> + 'a>,
     scalar: f32,
     wheel_scalar: f32,
     modifier_scalar: f32,
@@ -40,28 +40,33 @@ pub struct Knob<'a, Message, Renderer: self::Renderer> {
     mod_range_2: Option<&'a ModulationRange>,
 }
 
-impl<'a, Message, Renderer: self::Renderer> Knob<'a, Message, Renderer> {
+impl<'a, Message, Renderer> Knob<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
     /// Creates a new [`Knob`].
     ///
     /// It expects:
-    ///   * the local [`State`] of the [`Knob`]
+    ///   * the [`NormalParam`] of the [`Knob`]
     ///   * a function that will be called when the [`Knob`] is turned.
     ///
-    /// [`State`]: struct.State.html
+    /// [`NormalParam`]: struct.NormalParam.html
     /// [`Knob`]: struct.Knob.html
     pub fn new<F, G, H>(
-        state: &'a mut State,
+        normal_param: NormalParam,
         on_change: F,
+        // FIXME those two should probably be optionals
         on_drag_start: G,
         on_drag_end: H,
     ) -> Self
     where
-        F: 'static + Fn(Normal) -> Message,
-        G: 'static + Fn() -> Option<Message>,
-        H: 'static + Fn() -> Option<Message>,
+        F: 'a + Fn(Normal) -> Message,
+        G: 'a + Fn() -> Option<Message>,
+        H: 'a + Fn() -> Option<Message>,
     {
         Knob {
-            state,
+            normal_param,
             size: Length::from(Length::Units(DEFAULT_SIZE)),
             on_change: Box::new(on_change),
             on_drag_start: Box::new(on_drag_start),
@@ -202,26 +207,19 @@ impl<'a, Message, Renderer: self::Renderer> Knob<'a, Message, Renderer> {
 
     fn move_virtual_slider(
         &mut self,
-        messages: &mut Shell<'_, Message>,
+        state: &mut State,
+        shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
     ) {
-        if self.state.pressed_modifiers.contains(self.modifier_keys) {
+        if state.pressed_modifiers.contains(self.modifier_keys) {
             normal_delta *= self.modifier_scalar;
         }
 
-        let mut normal = self.state.continuous_normal - normal_delta;
+        self.normal_param.value =
+            Normal::new(state.continuous_normal - normal_delta);
+        state.continuous_normal = self.normal_param.value.as_f32();
 
-        if normal < 0.0 {
-            normal = 0.0;
-        } else if normal > 1.0 {
-            normal = 1.0;
-        }
-
-        self.state.continuous_normal = normal;
-
-        self.state.normal_param.value = normal.into();
-
-        messages.publish((self.on_change)(self.state.normal_param.value));
+        shell.publish((self.on_change)(self.normal_param.value));
     }
 }
 
@@ -229,11 +227,7 @@ impl<'a, Message, Renderer: self::Renderer> Knob<'a, Message, Renderer> {
 ///
 /// [`Knob`]: struct.Knob.html
 #[derive(Debug, Clone)]
-pub struct State {
-    /// The [`NormalParam`] assigned to this widget
-    ///
-    /// [`NormalParam`]: ../../core/normal_param/struct.NormalParam.html
-    pub normal_param: NormalParam,
+struct State {
     is_dragging: bool,
     prev_drag_y: f32,
     continuous_normal: f32,
@@ -247,75 +241,37 @@ impl State {
     /// Creates a new [`Knob`] state.
     ///
     /// It expects:
-    /// * a [`NormalParam`] to assign to this widget
+    /// * current [`Normal`] value for the [`Knob`]
     ///
-    /// [`NormalParam`]: ../../core/normal_param/struct.NormalParam.html
+    /// [`Normal`]: ../../core/normal/struct.Normal.html
     /// [`Knob`]: struct.Knob.html
-    pub fn new(normal_param: NormalParam) -> Self {
+    fn new(normal: Normal) -> Self {
         Self {
-            normal_param,
             is_dragging: false,
             prev_drag_y: 0.0,
-            continuous_normal: normal_param.value.as_f32(),
+            continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
             tick_marks_cache: Default::default(),
             text_marks_cache: Default::default(),
         }
     }
-
-    /// Set the normalized value of the [`Knob`].
-    pub fn set_normal(&mut self, normal: Normal) {
-        self.normal_param.value = normal;
-        self.continuous_normal = normal.into();
-    }
-
-    /// Get the normalized value of the [`Knob`].
-    pub fn normal(&self) -> Normal {
-        self.normal_param.value
-    }
-
-    /// Set the normalized default value of the [`Knob`].
-    pub fn set_default(&mut self, normal: Normal) {
-        self.normal_param.default = normal;
-    }
-
-    /// Get the normalized default value of the [`Knob`].
-    pub fn default(&self) -> Normal {
-        self.normal_param.default
-    }
-
-    /// Snap the visible value of the [`Knob`] to the nearest value
-    /// in the integer range.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use iced_audio::{knob, IntRange};
-    ///
-    /// let mut state = knob::State::new(Default::default());
-    /// let int_range = IntRange::new(0, 10);
-    ///
-    /// state.snap_visible_to(&int_range);
-    ///
-    /// ```
-    pub fn snap_visible_to(&mut self, range: &IntRange) {
-        self.normal_param.value = range.snapped(self.normal_param.value);
-    }
-
-    /// Is the [`Knob`] currently in the dragging state?
-    ///
-    /// [`Knob`]: struct.Knob.html
-    pub fn is_dragging(&self) -> bool {
-        self.is_dragging
-    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Knob<'a, Message, Renderer>
 where
+    Message: Clone,
     Renderer: self::Renderer,
 {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::new(self.normal_param.value))
+    }
+
     fn width(&self) -> Length {
         self.size
     }
@@ -338,121 +294,124 @@ where
 
     fn on_event(
         &mut self,
+        state: &mut Tree,
         event: Event,
         layout: Layout<'_>,
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Shell<'_, Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
+        let state = state.state.downcast_mut::<State>();
+
         match event {
-            Event::Mouse(mouse_event) => match mouse_event {
-                mouse::Event::CursorMoved { .. } => {
-                    if self.state.is_dragging {
-                        let normal_delta = (cursor_position.y
-                            - self.state.prev_drag_y)
-                            * self.scalar;
+            Event::Mouse(mouse::Event::CursorMoved { .. })
+            | Event::Touch(touch::Event::FingerMoved { .. }) => {
+                if state.is_dragging {
+                    let normal_delta =
+                        (cursor_position.y - state.prev_drag_y) * self.scalar;
 
-                        self.state.prev_drag_y = cursor_position.y;
+                    state.prev_drag_y = cursor_position.y;
 
-                        self.move_virtual_slider(messages, normal_delta);
+                    self.move_virtual_slider(state, shell, normal_delta);
+
+                    return event::Status::Captured;
+                }
+            }
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if self.wheel_scalar == 0.0 {
+                    return event::Status::Ignored;
+                }
+
+                if layout.bounds().contains(cursor_position) {
+                    let lines = match delta {
+                        iced_native::mouse::ScrollDelta::Lines {
+                            y, ..
+                        } => y,
+                        iced_native::mouse::ScrollDelta::Pixels {
+                            y, ..
+                        } => {
+                            if y > 0.0 {
+                                1.0
+                            } else if y < 0.0 {
+                                -1.0
+                            } else {
+                                0.0
+                            }
+                        }
+                    };
+
+                    if lines != 0.0 {
+                        let normal_delta = -lines * self.wheel_scalar;
+
+                        self.move_virtual_slider(state, shell, normal_delta);
 
                         return event::Status::Captured;
                     }
                 }
-                mouse::Event::WheelScrolled { delta } => {
-                    if self.wheel_scalar == 0.0 {
-                        return event::Status::Ignored;
-                    }
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if layout.bounds().contains(cursor_position) {
+                    let click =
+                        mouse::Click::new(cursor_position, state.last_click);
 
-                    if layout.bounds().contains(cursor_position) {
-                        let lines = match delta {
-                            iced_native::mouse::ScrollDelta::Lines {
-                                y,
-                                ..
-                            } => y,
-                            iced_native::mouse::ScrollDelta::Pixels {
-                                y,
-                                ..
-                            } => {
-                                if y > 0.0 {
-                                    1.0
-                                } else if y < 0.0 {
-                                    -1.0
-                                } else {
-                                    0.0
-                                }
-                            }
-                        };
+                    match click.kind() {
+                        mouse::click::Kind::Single => {
+                            state.is_dragging = true;
+                            state.prev_drag_y = cursor_position.y;
+                            state.continuous_normal =
+                                self.normal_param.value.as_f32();
 
-                        if lines != 0.0 {
-                            let normal_delta = -lines * self.wheel_scalar;
-
-                            self.move_virtual_slider(messages, normal_delta);
-
-                            return event::Status::Captured;
-                        }
-                    }
-                }
-                mouse::Event::ButtonPressed(mouse::Button::Left) => {
-                    if layout.bounds().contains(cursor_position) {
-                        let click = mouse::Click::new(
-                            cursor_position,
-                            self.state.last_click,
-                        );
-
-                        match click.kind() {
-                            mouse::click::Kind::Single => {
-                                self.state.is_dragging = true;
-                                self.state.prev_drag_y = cursor_position.y;
-
-                                if let Some(message) = (self.on_drag_start)() {
-                                    messages.publish(message);
-                                }
-                            }
-                            _ => {
-                                self.state.is_dragging = false;
-
-                                self.state.normal_param.value =
-                                    self.state.normal_param.default;
-
-                                messages.publish((self.on_change)(
-                                    self.state.normal_param.value,
-                                ));
+                            if let Some(message) = (self.on_drag_start)() {
+                                shell.publish(message);
                             }
                         }
+                        _ => {
+                            state.is_dragging = false;
 
-                        self.state.last_click = Some(click);
+                            self.normal_param.value = self.normal_param.default;
+                            state.continuous_normal =
+                                self.normal_param.default.as_f32();
 
-                        return event::Status::Captured;
+                            shell.publish((self.on_change)(
+                                self.normal_param.value,
+                            ));
+                        }
                     }
+
+                    state.last_click = Some(click);
+
+                    return event::Status::Captured;
                 }
-                mouse::Event::ButtonReleased(mouse::Button::Left) => {
-                    self.state.is_dragging = false;
-                    self.state.continuous_normal =
-                        self.state.normal_param.value.as_f32();
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. })
+            | Event::Touch(touch::Event::FingerLost { .. }) => {
+                if state.is_dragging {
+                    state.is_dragging = false;
+                    state.continuous_normal = self.normal_param.value.as_f32();
 
                     if let Some(message) = (self.on_drag_end)() {
-                        messages.publish(message);
+                        shell.publish(message);
                     }
 
                     return event::Status::Captured;
                 }
-                _ => {}
-            },
+            }
             Event::Keyboard(keyboard_event) => match keyboard_event {
                 keyboard::Event::KeyPressed { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::KeyReleased { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::ModifiersChanged(modifiers) => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
@@ -466,25 +425,28 @@ where
 
     fn draw(
         &self,
+        state: &Tree,
         renderer: &mut Renderer,
+        _theme: &Renderer::Theme,
         _style: &iced_native::renderer::Style,
         layout: Layout<'_>,
         cursor_position: Point,
         _viewport: &Rectangle,
     ) {
+        let state = state.state.downcast_ref::<State>();
         renderer.draw(
             layout.bounds(),
             cursor_position,
-            self.state.normal_param.value,
+            self.normal_param.value,
             self.bipolar_center,
-            self.state.is_dragging,
+            state.is_dragging,
             self.mod_range_1,
             self.mod_range_2,
             self.tick_marks,
             self.text_marks,
             &self.style,
-            &self.state.tick_marks_cache,
-            &self.state.text_marks_cache,
+            &state.tick_marks_cache,
+            &state.text_marks_cache,
         )
     }
 }
@@ -532,8 +494,8 @@ pub trait Renderer: iced_native::Renderer {
 impl<'a, Message, Renderer> From<Knob<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
+    Message: 'a + Clone,
     Renderer: 'a + self::Renderer,
-    Message: 'a,
 {
     fn from(
         knob: Knob<'a, Message, Renderer>,

--- a/src/native/knob.rs
+++ b/src/native/knob.rs
@@ -11,7 +11,7 @@ use iced_native::{
 };
 
 use crate::core::{ModulationRange, Normal, NormalParam};
-use crate::native::{text_marks, tick_marks, VirtualSliderStatus};
+use crate::native::{text_marks, tick_marks, SliderStatus};
 use crate::style::knob::StyleSheet;
 
 static DEFAULT_SIZE: u16 = 30;
@@ -31,7 +31,8 @@ where
     normal_param: NormalParam,
     size: Length,
     on_change: Box<dyn 'a + Fn(Normal) -> Message>,
-    on_release: Option<Message>,
+    on_grab: Option<Box<dyn 'a + FnMut() -> Option<Message>>>,
+    on_release: Option<Box<dyn 'a + FnMut() -> Option<Message>>>,
     scalar: f32,
     wheel_scalar: f32,
     modifier_scalar: f32,
@@ -46,7 +47,6 @@ where
 
 impl<'a, Message, Renderer> Knob<'a, Message, Renderer>
 where
-    Message: Clone,
     Renderer: self::Renderer,
     Renderer::Theme: StyleSheet,
 {
@@ -66,6 +66,7 @@ where
             normal_param,
             size: Length::from(Length::Units(DEFAULT_SIZE)),
             on_change: Box::new(on_change),
+            on_grab: None,
             on_release: None,
             scalar: DEFAULT_SCALAR,
             wheel_scalar: DEFAULT_WHEEL_SCALAR,
@@ -80,14 +81,31 @@ where
         }
     }
 
+    /// Sets the grab message of the [`Knob`].
+    /// This is called when the mouse grabs from the knob.
+    ///
+    /// Typically, the user's interaction with the knob starts when this message is produced.
+    /// This is useful for some environments so that external changes, such as automation,
+    /// don't interfer with user's changes.
+    pub fn on_grab(
+        mut self,
+        on_grab: impl 'a + FnMut() -> Option<Message>,
+    ) -> Self {
+        self.on_grab = Some(Box::new(on_grab));
+        self
+    }
+
     /// Sets the release message of the [`Knob`].
     /// This is called when the mouse is released from the knob.
     ///
     /// Typically, the user's interaction with the knob is finished when this message is produced.
     /// This is useful if you need to spawn a long-running task from the knob's result, where
     /// the default on_change message could create too many events.
-    pub fn on_release(mut self, on_release: Message) -> Self {
-        self.on_release = Some(on_release);
+    pub fn on_release(
+        mut self,
+        on_release: impl 'a + FnMut() -> Option<Message>,
+    ) -> Self {
+        self.on_release = Some(Box::new(on_release));
         self
     }
 
@@ -218,11 +236,10 @@ where
     fn move_virtual_slider(
         &mut self,
         state: &mut State,
-        shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
-    ) -> VirtualSliderStatus {
+    ) -> SliderStatus {
         if normal_delta.abs() < f32::EPSILON {
-            return VirtualSliderStatus::Unchanged;
+            return SliderStatus::Unchanged;
         }
 
         if state.pressed_modifiers.contains(self.modifier_keys) {
@@ -233,9 +250,27 @@ where
             Normal::new(state.continuous_normal - normal_delta);
         state.continuous_normal = self.normal_param.value.as_f32();
 
-        shell.publish((self.on_change)(self.normal_param.value));
+        SliderStatus::Moved
+    }
 
-        VirtualSliderStatus::Moved
+    fn maybe_fire_on_grab(&mut self, shell: &mut Shell<'_, Message>) {
+        if let Some(message) =
+            self.on_grab.as_mut().and_then(|on_grab| on_grab())
+        {
+            shell.publish(message);
+        }
+    }
+
+    fn fire_on_change(&self, shell: &mut Shell<'_, Message>) {
+        shell.publish((self.on_change)(self.normal_param.value));
+    }
+
+    fn maybe_fire_on_release(&mut self, shell: &mut Shell<'_, Message>) {
+        if let Some(message) =
+            self.on_release.as_mut().and_then(|on_release| on_release())
+        {
+            shell.publish(message);
+        }
     }
 }
 
@@ -244,7 +279,7 @@ where
 /// [`Knob`]: struct.Knob.html
 #[derive(Debug, Clone)]
 struct State {
-    dragging_status: Option<VirtualSliderStatus>,
+    dragging_status: Option<SliderStatus>,
     prev_drag_y: f32,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
@@ -277,7 +312,6 @@ impl State {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Knob<'a, Message, Renderer>
 where
-    Message: Clone,
     Renderer: self::Renderer,
     Renderer::Theme: StyleSheet,
 {
@@ -330,13 +364,16 @@ where
 
                     state.prev_drag_y = cursor_position.y;
 
-                    let slider_status =
-                        self.move_virtual_slider(state, shell, normal_delta);
-                    state
-                        .dragging_status
-                        .as_mut()
-                        .expect("dragging_status taken")
-                        .update_with(slider_status);
+                    if self.move_virtual_slider(state, normal_delta).was_moved()
+                    {
+                        self.fire_on_change(shell);
+
+                        state
+                            .dragging_status
+                            .as_mut()
+                            .expect("dragging_status taken")
+                            .moved();
+                    }
 
                     return event::Status::Captured;
                 }
@@ -368,11 +405,22 @@ where
                         let normal_delta = -lines * self.wheel_scalar;
 
                         if self
-                            .move_virtual_slider(state, shell, normal_delta)
+                            .move_virtual_slider(state, normal_delta)
                             .was_moved()
                         {
-                            if let Some(on_release) = self.on_release.clone() {
-                                shell.publish(on_release);
+                            if state.dragging_status.is_none() {
+                                self.maybe_fire_on_grab(shell);
+                            }
+
+                            self.fire_on_change(shell);
+
+                            if let Some(slider_status) =
+                                state.dragging_status.as_mut()
+                            {
+                                // Widget was grabbed => keep it grabbed
+                                slider_status.moved();
+                            } else {
+                                self.maybe_fire_on_release(shell);
                             }
                         }
 
@@ -388,24 +436,36 @@ where
 
                     match click.kind() {
                         mouse::click::Kind::Single => {
+                            self.maybe_fire_on_grab(shell);
+
                             state.dragging_status = Some(Default::default());
                             state.prev_drag_y = cursor_position.y;
                             state.continuous_normal =
                                 self.normal_param.value.as_f32();
                         }
                         _ => {
-                            state.dragging_status = None;
+                            // Reset to default
 
-                            self.normal_param.value = self.normal_param.default;
-                            state.continuous_normal =
-                                self.normal_param.default.as_f32();
+                            let prev_dragging_status =
+                                state.dragging_status.take();
 
-                            shell.publish((self.on_change)(
-                                self.normal_param.value,
-                            ));
+                            if self.normal_param.value
+                                != self.normal_param.default
+                            {
+                                if prev_dragging_status.is_none() {
+                                    self.maybe_fire_on_grab(shell);
+                                }
 
-                            if let Some(on_release) = self.on_release.clone() {
-                                shell.publish(on_release);
+                                self.normal_param.value =
+                                    self.normal_param.default;
+                                state.continuous_normal =
+                                    self.normal_param.default.as_f32();
+
+                                self.fire_on_change(shell);
+
+                                self.maybe_fire_on_release(shell);
+                            } else if prev_dragging_status.is_some() {
+                                self.maybe_fire_on_release(shell);
                             }
                         }
                     }
@@ -419,10 +479,10 @@ where
             | Event::Touch(touch::Event::FingerLifted { .. })
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 if let Some(slider_status) = state.dragging_status.take() {
-                    if slider_status.was_moved() {
-                        if let Some(on_release) = self.on_release.clone() {
-                            shell.publish(on_release);
-                        }
+                    if self.on_grab.is_some() || slider_status.was_moved() {
+                        // maybe fire on release if `on_grab` is defined
+                        // so as to terminate the action, regardless of the actual user movement.
+                        self.maybe_fire_on_release(shell);
                     }
 
                     state.continuous_normal = self.normal_param.value.as_f32();
@@ -529,7 +589,7 @@ where
 impl<'a, Message, Renderer> From<Knob<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Message: 'a + Clone,
+    Message: 'a,
     Renderer: 'a + self::Renderer,
     Renderer::Theme: 'a + StyleSheet,
 {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -21,3 +21,30 @@ pub use ramp::Ramp;
 pub use v_slider::VSlider;
 #[doc(no_inline)]
 pub use xy_pad::XYPad;
+
+/// Moved status for the virtual sliders.
+///
+/// This allows tracking the virtual slider actual movements
+/// thus preventing some events from unnecessary being emitted.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum VirtualSliderStatus {
+    Moved,
+    #[default]
+    Unchanged,
+}
+
+impl VirtualSliderStatus {
+    /// Updates current value with the provided `update`.
+    ///
+    /// Doesn't change `self` if `update` is `Unchanged`.
+    pub(crate) fn update_with(&mut self, update: Self) {
+        if matches!(update, VirtualSliderStatus::Moved) {
+            *self = VirtualSliderStatus::Moved;
+        }
+    }
+
+    /// Whether the virtual slider status was moved.
+    pub(crate) fn was_moved(self) -> bool {
+        matches!(self, VirtualSliderStatus::Moved)
+    }
+}

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -27,24 +27,20 @@ pub use xy_pad::XYPad;
 /// This allows tracking the virtual slider actual movements
 /// thus preventing some events from unnecessary being emitted.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-pub(crate) enum VirtualSliderStatus {
+pub(crate) enum SliderStatus {
     Moved,
     #[default]
     Unchanged,
 }
 
-impl VirtualSliderStatus {
-    /// Updates current value with the provided `update`.
-    ///
-    /// Doesn't change `self` if `update` is `Unchanged`.
-    pub(crate) fn update_with(&mut self, update: Self) {
-        if matches!(update, VirtualSliderStatus::Moved) {
-            *self = VirtualSliderStatus::Moved;
-        }
+impl SliderStatus {
+    /// Sets the slider as moved.
+    pub(crate) fn moved(&mut self) {
+        *self = SliderStatus::Moved;
     }
 
-    /// Whether the virtual slider status was moved.
+    /// Whether the slider was moved.
     pub(crate) fn was_moved(self) -> bool {
-        matches!(self, VirtualSliderStatus::Moved)
+        matches!(self, SliderStatus::Moved)
     }
 }

--- a/src/native/mod_range_input.rs
+++ b/src/native/mod_range_input.rs
@@ -136,6 +136,10 @@ where
         shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
     ) {
+        if normal_delta.abs() < f32::EPSILON {
+            return;
+        }
+
         if state.pressed_modifiers.contains(self.modifier_keys) {
             normal_delta *= self.modifier_scalar;
         }

--- a/src/native/ramp.rs
+++ b/src/native/ramp.rs
@@ -176,6 +176,10 @@ where
         shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
     ) {
+        if normal_delta.abs() < f32::EPSILON {
+            return;
+        }
+
         if state.pressed_modifiers.contains(self.modifier_keys) {
             normal_delta *= self.modifier_scalar;
         }

--- a/src/native/ramp.rs
+++ b/src/native/ramp.rs
@@ -5,13 +5,13 @@
 
 use std::fmt::Debug;
 
+use iced_native::widget::tree::{self, Tree};
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
-    Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, touch, Clipboard, Element, Event, Layout,
+    Length, Point, Rectangle, Shell, Size, Widget,
 };
 
 use crate::core::{Normal, NormalParam};
-use crate::IntRange;
 
 static DEFAULT_WIDTH: u16 = 40;
 static DEFAULT_HEIGHT: u16 = 20;
@@ -40,8 +40,8 @@ impl Default for RampDirection {
 /// [`NormalParam`]: ../../core/normal_param/struct.NormalParam.html
 /// [`Ramp`]: struct.Ramp.html
 #[allow(missing_debug_implementations)]
-pub struct Ramp<'a, Message, Renderer: self::Renderer> {
-    state: &'a mut State,
+pub struct Ramp<Message, Renderer: self::Renderer> {
+    normal_param: NormalParam,
     on_change: Box<dyn Fn(Normal) -> Message>,
     scalar: f32,
     wheel_scalar: f32,
@@ -53,21 +53,25 @@ pub struct Ramp<'a, Message, Renderer: self::Renderer> {
     direction: RampDirection,
 }
 
-impl<'a, Message, Renderer: self::Renderer> Ramp<'a, Message, Renderer> {
+impl<Message, Renderer: self::Renderer> Ramp<Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
     /// Creates a new [`Ramp`].
     ///
     /// It expects:
-    ///   * the local [`State`] of the [`Ramp`]
+    ///   * the [`NormalParam`] of the [`Ramp`]
     ///   * a function that will be called when the [`Ramp`] is dragged.
     ///   * the [`RampDirection`] of the [`Ramp`], which tells if the ramp line
     /// should point `Up` (from `bottom-left` to `top-right`), or `Down` (from
     /// `top-left` to `bottom-right`)
     ///
     /// [`RampDirection`]: enum.RampDirection.html
-    /// [`State`]: struct.State.html
+    /// [`NormalParam`]: struct.NormalParam.html
     /// [`Ramp`]: struct.Ramp.html
     pub fn new<F>(
-        state: &'a mut State,
+        normal_param: NormalParam,
         on_change: F,
         direction: RampDirection,
     ) -> Self
@@ -75,7 +79,7 @@ impl<'a, Message, Renderer: self::Renderer> Ramp<'a, Message, Renderer> {
         F: 'static + Fn(Normal) -> Message,
     {
         Ramp {
-            state,
+            normal_param,
             on_change: Box::new(on_change),
             scalar: DEFAULT_SCALAR,
             wheel_scalar: DEFAULT_WHEEL_SCALAR,
@@ -168,26 +172,19 @@ impl<'a, Message, Renderer: self::Renderer> Ramp<'a, Message, Renderer> {
 
     fn move_virtual_slider(
         &mut self,
-        messages: &mut Shell<'_, Message>,
+        state: &mut State,
+        shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
     ) {
-        if self.state.pressed_modifiers.contains(self.modifier_keys) {
+        if state.pressed_modifiers.contains(self.modifier_keys) {
             normal_delta *= self.modifier_scalar;
         }
 
-        let mut normal = self.state.continuous_normal - normal_delta;
+        self.normal_param.value =
+            (state.continuous_normal - normal_delta).into();
+        state.continuous_normal = self.normal_param.value.as_f32();
 
-        if normal < 0.0 {
-            normal = 0.0;
-        } else if normal > 1.0 {
-            normal = 1.0;
-        }
-
-        self.state.continuous_normal = normal;
-
-        self.state.normal_param.value = normal.into();
-
-        messages.publish((self.on_change)(self.state.normal_param.value));
+        shell.publish((self.on_change)(self.normal_param.value));
     }
 }
 
@@ -195,8 +192,7 @@ impl<'a, Message, Renderer: self::Renderer> Ramp<'a, Message, Renderer> {
 ///
 /// [`Ramp`]: struct.Ramp.html
 #[derive(Debug, Copy, Clone)]
-pub struct State {
-    normal_param: NormalParam,
+struct State {
     is_dragging: bool,
     prev_drag_y: f32,
     continuous_normal: f32,
@@ -208,76 +204,37 @@ impl State {
     /// Creates a new [`Ramp`] state.
     ///
     /// It expects:
-    /// * a [`NormalParam`] to assign to this widget. A [`NormalParam`] with a [`Normal`]
-    /// value of `0.5` represents a straight line, `0.0` is curved downward all
-    /// the way, and `1.0` is curved upward all the way.
+    /// * current [`Normal`] value for the [`Ramp`].
+    /// A [`Normal`] value of `0.5` represents a straight line,
+    /// `0.0` is curved downward all the way,
+    /// and `1.0` is curved upward all the way.
     ///
-    /// [`NormalParam`]: ../../core/normal_param/struct.NormalParam.html
     /// [`Normal`]: ../../core/struct.Normal.html
     /// [`Ramp`]: struct.Ramp.html
-    pub fn new(normal_param: NormalParam) -> Self {
+    fn new(normal: Normal) -> Self {
         Self {
-            normal_param,
             is_dragging: false,
             prev_drag_y: 0.0,
-            continuous_normal: normal_param.value.as_f32(),
+            continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
         }
     }
-
-    /// Set the normalized value of the [`Ramp`].
-    pub fn set_normal(&mut self, normal: Normal) {
-        self.normal_param.value = normal;
-        self.continuous_normal = normal.into();
-    }
-
-    /// Get the normalized value of the [`Ramp`].
-    pub fn normal(&self) -> Normal {
-        self.normal_param.value
-    }
-
-    /// Set the normalized default value of the [`Ramp`].
-    pub fn set_default(&mut self, normal: Normal) {
-        self.normal_param.default = normal;
-    }
-
-    /// Get the normalized default value of the [`Ramp`].
-    pub fn default(&self) -> Normal {
-        self.normal_param.default
-    }
-
-    /// Snap the visible value of the [`Ramp`] to the nearest value
-    /// in the integer range.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use iced_audio::{ramp, IntRange};
-    ///
-    /// let mut state = ramp::State::new(Default::default());
-    /// let int_range = IntRange::new(0, 10);
-    ///
-    /// state.snap_visible_to(&int_range);
-    ///
-    /// ```
-    pub fn snap_visible_to(&mut self, range: &IntRange) {
-        self.normal_param.value = range.snapped(self.normal_param.value);
-    }
-
-    /// Is the [`Ramp`] currently in the dragging state?
-    ///
-    /// [`Ramp`]: struct.Ramp.html
-    pub fn is_dragging(&self) -> bool {
-        self.is_dragging
-    }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for Ramp<'a, Message, Renderer>
+impl<Message, Renderer> Widget<Message, Renderer> for Ramp<Message, Renderer>
 where
+    Message: Clone,
     Renderer: self::Renderer,
 {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::new(self.normal_param.value))
+    }
+
     fn width(&self) -> Length {
         self.width
     }
@@ -300,115 +257,116 @@ where
 
     fn on_event(
         &mut self,
+        state: &mut Tree,
         event: Event,
         layout: Layout<'_>,
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Shell<'_, Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
+        let state = state.state.downcast_mut::<State>();
+
         match event {
-            Event::Mouse(mouse_event) => match mouse_event {
-                mouse::Event::CursorMoved { .. } => {
-                    if self.state.is_dragging {
-                        if self.state.is_dragging {
-                            let normal_delta = (cursor_position.y
-                                - self.state.prev_drag_y)
-                                * self.scalar;
+            Event::Mouse(mouse::Event::CursorMoved { .. })
+            | Event::Touch(touch::Event::FingerMoved { .. }) => {
+                if state.is_dragging {
+                    let normal_delta =
+                        (cursor_position.y - state.prev_drag_y) * self.scalar;
 
-                            self.state.prev_drag_y = cursor_position.y;
+                    state.prev_drag_y = cursor_position.y;
 
-                            self.move_virtual_slider(messages, normal_delta);
+                    self.move_virtual_slider(state, shell, normal_delta);
 
-                            return event::Status::Captured;
-                        }
-                    }
+                    return event::Status::Captured;
                 }
-                mouse::Event::WheelScrolled { delta } => {
-                    if self.wheel_scalar == 0.0 {
-                        return event::Status::Ignored;
-                    }
-
-                    if layout.bounds().contains(cursor_position) {
-                        let lines = match delta {
-                            iced_native::mouse::ScrollDelta::Lines {
-                                y,
-                                ..
-                            } => y,
-                            iced_native::mouse::ScrollDelta::Pixels {
-                                y,
-                                ..
-                            } => {
-                                if y > 0.0 {
-                                    1.0
-                                } else if y < 0.0 {
-                                    -1.0
-                                } else {
-                                    0.0
-                                }
-                            }
-                        };
-
-                        if lines != 0.0 {
-                            let normal_delta = -lines * self.wheel_scalar;
-
-                            self.move_virtual_slider(messages, normal_delta);
-
-                            return event::Status::Captured;
-                        }
-                    }
+            }
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if self.wheel_scalar == 0.0 {
+                    return event::Status::Ignored;
                 }
-                mouse::Event::ButtonPressed(mouse::Button::Left) => {
-                    if layout.bounds().contains(cursor_position) {
-                        let click = mouse::Click::new(
-                            cursor_position,
-                            self.state.last_click,
-                        );
 
-                        match click.kind() {
-                            mouse::click::Kind::Single => {
-                                self.state.is_dragging = true;
-                                self.state.prev_drag_y = cursor_position.y;
-                            }
-                            _ => {
-                                self.state.is_dragging = false;
-
-                                self.state.normal_param.value =
-                                    self.state.normal_param.default;
-
-                                messages.publish((self.on_change)(
-                                    self.state.normal_param.value,
-                                ));
+                if layout.bounds().contains(cursor_position) {
+                    let lines = match delta {
+                        iced_native::mouse::ScrollDelta::Lines {
+                            y, ..
+                        } => y,
+                        iced_native::mouse::ScrollDelta::Pixels {
+                            y, ..
+                        } => {
+                            if y > 0.0 {
+                                1.0
+                            } else if y < 0.0 {
+                                -1.0
+                            } else {
+                                0.0
                             }
                         }
+                    };
 
-                        self.state.last_click = Some(click);
+                    if lines != 0.0 {
+                        let normal_delta = -lines * self.wheel_scalar;
+
+                        self.move_virtual_slider(state, shell, normal_delta);
 
                         return event::Status::Captured;
                     }
                 }
-                mouse::Event::ButtonReleased(mouse::Button::Left) => {
-                    self.state.is_dragging = false;
-                    self.state.continuous_normal =
-                        self.state.normal_param.value.as_f32();
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if layout.bounds().contains(cursor_position) {
+                    let click =
+                        mouse::Click::new(cursor_position, state.last_click);
+
+                    match click.kind() {
+                        mouse::click::Kind::Single => {
+                            state.is_dragging = true;
+                            state.prev_drag_y = cursor_position.y;
+                            state.continuous_normal =
+                                self.normal_param.value.as_f32();
+                        }
+                        _ => {
+                            state.is_dragging = false;
+
+                            self.normal_param.value = self.normal_param.default;
+                            state.continuous_normal =
+                                self.normal_param.default.as_f32();
+
+                            shell.publish((self.on_change)(
+                                self.normal_param.value,
+                            ));
+                        }
+                    }
+
+                    state.last_click = Some(click);
 
                     return event::Status::Captured;
                 }
-                _ => {}
-            },
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. })
+            | Event::Touch(touch::Event::FingerLost { .. }) => {
+                if state.is_dragging {
+                    state.is_dragging = false;
+                    state.continuous_normal = self.normal_param.value.as_f32();
+
+                    return event::Status::Captured;
+                }
+            }
             Event::Keyboard(keyboard_event) => match keyboard_event {
                 keyboard::Event::KeyPressed { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::KeyReleased { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::ModifiersChanged(modifiers) => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
@@ -422,17 +380,20 @@ where
 
     fn draw(
         &self,
+        state: &Tree,
         renderer: &mut Renderer,
+        _theme: &Renderer::Theme,
         _style: &iced_native::renderer::Style,
         layout: Layout<'_>,
         cursor_position: Point,
         _viewport: &Rectangle,
     ) {
+        let state = state.state.downcast_ref::<State>();
         renderer.draw(
             layout.bounds(),
             cursor_position,
-            self.state.normal_param.value,
-            self.state.is_dragging,
+            self.normal_param.value,
+            state.is_dragging,
             &self.style,
             self.direction,
         )
@@ -471,15 +432,15 @@ pub trait Renderer: iced_native::Renderer {
     );
 }
 
-impl<'a, Message, Renderer> From<Ramp<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<Message, Renderer> From<Ramp<Message, Renderer>>
+    for Element<'_, Message, Renderer>
 where
-    Renderer: 'a + self::Renderer,
-    Message: 'a,
+    Message: 'static + Clone,
+    Renderer: 'static + self::Renderer,
 {
     fn from(
-        ramp: Ramp<'a, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        ramp: Ramp<Message, Renderer>,
+    ) -> Element<'static, Message, Renderer> {
         Element::new(ramp)
     }
 }

--- a/src/native/ramp.rs
+++ b/src/native/ramp.rs
@@ -12,7 +12,7 @@ use iced_native::{
 };
 
 use crate::core::{Normal, NormalParam};
-use crate::native::VirtualSliderStatus;
+use crate::native::SliderStatus;
 use crate::style::ramp::StyleSheet;
 
 static DEFAULT_WIDTH: u16 = 40;
@@ -49,7 +49,8 @@ where
 {
     normal_param: NormalParam,
     on_change: Box<dyn 'a + Fn(Normal) -> Message>,
-    on_release: Option<Message>,
+    on_grab: Option<Box<dyn 'a + FnMut() -> Option<Message>>>,
+    on_release: Option<Box<dyn 'a + FnMut() -> Option<Message>>>,
     scalar: f32,
     wheel_scalar: f32,
     modifier_scalar: f32,
@@ -62,7 +63,6 @@ where
 
 impl<'a, Message, Renderer> Ramp<'a, Message, Renderer>
 where
-    Message: Clone,
     Renderer: self::Renderer,
     Renderer::Theme: StyleSheet,
 {
@@ -89,6 +89,7 @@ where
         Ramp {
             normal_param,
             on_change: Box::new(on_change),
+            on_grab: None,
             on_release: None,
             scalar: DEFAULT_SCALAR,
             wheel_scalar: DEFAULT_WHEEL_SCALAR,
@@ -101,14 +102,31 @@ where
         }
     }
 
+    /// Sets the grab message of the [`Ramp`].
+    /// This is called when the mouse grabs from the ramp.
+    ///
+    /// Typically, the user's interaction with the ramp starts when this message is produced.
+    /// This is useful for some environments so that external changes, such as automation,
+    /// don't interfer with user's changes.
+    pub fn on_grab(
+        mut self,
+        on_grab: impl 'a + FnMut() -> Option<Message>,
+    ) -> Self {
+        self.on_grab = Some(Box::new(on_grab));
+        self
+    }
+
     /// Sets the release message of the [`Ramp`].
     /// This is called when the mouse is released from the ramp.
     ///
     /// Typically, the user's interaction with the ramp is finished when this message is produced.
     /// This is useful if you need to spawn a long-running task from the ramp's result, where
     /// the default on_change message could create too many events.
-    pub fn on_release(mut self, on_release: Message) -> Self {
-        self.on_release = Some(on_release);
+    pub fn on_release(
+        mut self,
+        on_release: impl 'a + FnMut() -> Option<Message>,
+    ) -> Self {
+        self.on_release = Some(Box::new(on_release));
         self
     }
 
@@ -196,11 +214,10 @@ where
     fn move_virtual_slider(
         &mut self,
         state: &mut State,
-        shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
-    ) -> VirtualSliderStatus {
+    ) -> SliderStatus {
         if normal_delta.abs() < f32::EPSILON {
-            return VirtualSliderStatus::Unchanged;
+            return SliderStatus::Unchanged;
         }
 
         if state.pressed_modifiers.contains(self.modifier_keys) {
@@ -211,9 +228,27 @@ where
             (state.continuous_normal - normal_delta).into();
         state.continuous_normal = self.normal_param.value.as_f32();
 
-        shell.publish((self.on_change)(self.normal_param.value));
+        SliderStatus::Moved
+    }
 
-        VirtualSliderStatus::Moved
+    fn maybe_fire_on_grab(&mut self, shell: &mut Shell<'_, Message>) {
+        if let Some(message) =
+            self.on_grab.as_mut().and_then(|on_grab| on_grab())
+        {
+            shell.publish(message);
+        }
+    }
+
+    fn fire_on_change(&self, shell: &mut Shell<'_, Message>) {
+        shell.publish((self.on_change)(self.normal_param.value));
+    }
+
+    fn maybe_fire_on_release(&mut self, shell: &mut Shell<'_, Message>) {
+        if let Some(message) =
+            self.on_release.as_mut().and_then(|on_release| on_release())
+        {
+            shell.publish(message);
+        }
     }
 }
 
@@ -222,7 +257,7 @@ where
 /// [`Ramp`]: struct.Ramp.html
 #[derive(Debug, Copy, Clone)]
 struct State {
-    dragging_status: Option<VirtualSliderStatus>,
+    dragging_status: Option<SliderStatus>,
     prev_drag_y: f32,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
@@ -254,7 +289,6 @@ impl State {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Ramp<'a, Message, Renderer>
 where
-    Message: Clone,
     Renderer: self::Renderer,
     Renderer::Theme: StyleSheet,
 {
@@ -307,13 +341,16 @@ where
 
                     state.prev_drag_y = cursor_position.y;
 
-                    let slider_status =
-                        self.move_virtual_slider(state, shell, normal_delta);
-                    state
-                        .dragging_status
-                        .as_mut()
-                        .expect("dragging_status taken")
-                        .update_with(slider_status);
+                    if self.move_virtual_slider(state, normal_delta).was_moved()
+                    {
+                        self.fire_on_change(shell);
+
+                        state
+                            .dragging_status
+                            .as_mut()
+                            .expect("dragging_status taken")
+                            .moved();
+                    }
 
                     return event::Status::Captured;
                 }
@@ -345,11 +382,22 @@ where
                         let normal_delta = -lines * self.wheel_scalar;
 
                         if self
-                            .move_virtual_slider(state, shell, normal_delta)
+                            .move_virtual_slider(state, normal_delta)
                             .was_moved()
                         {
-                            if let Some(on_release) = self.on_release.clone() {
-                                shell.publish(on_release);
+                            if state.dragging_status.is_none() {
+                                self.maybe_fire_on_grab(shell);
+                            }
+
+                            self.fire_on_change(shell);
+
+                            if let Some(slider_status) =
+                                state.dragging_status.as_mut()
+                            {
+                                // Widget was grabbed => keep it grabbed
+                                slider_status.moved();
+                            } else {
+                                self.maybe_fire_on_release(shell);
                             }
                         }
 
@@ -365,24 +413,36 @@ where
 
                     match click.kind() {
                         mouse::click::Kind::Single => {
+                            self.maybe_fire_on_grab(shell);
+
                             state.dragging_status = Some(Default::default());
                             state.prev_drag_y = cursor_position.y;
                             state.continuous_normal =
                                 self.normal_param.value.as_f32();
                         }
                         _ => {
-                            state.dragging_status = None;
+                            // Reset to default
 
-                            self.normal_param.value = self.normal_param.default;
-                            state.continuous_normal =
-                                self.normal_param.default.as_f32();
+                            let prev_dragging_status =
+                                state.dragging_status.take();
 
-                            shell.publish((self.on_change)(
-                                self.normal_param.value,
-                            ));
+                            if self.normal_param.value
+                                != self.normal_param.default
+                            {
+                                if prev_dragging_status.is_none() {
+                                    self.maybe_fire_on_grab(shell);
+                                }
 
-                            if let Some(on_release) = self.on_release.clone() {
-                                shell.publish(on_release);
+                                self.normal_param.value =
+                                    self.normal_param.default;
+                                state.continuous_normal =
+                                    self.normal_param.default.as_f32();
+
+                                self.fire_on_change(shell);
+
+                                self.maybe_fire_on_release(shell);
+                            } else if prev_dragging_status.is_some() {
+                                self.maybe_fire_on_release(shell);
                             }
                         }
                     }
@@ -396,10 +456,10 @@ where
             | Event::Touch(touch::Event::FingerLifted { .. })
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 if let Some(slider_status) = state.dragging_status.take() {
-                    if slider_status.was_moved() {
-                        if let Some(on_release) = self.on_release.clone() {
-                            shell.publish(on_release);
-                        }
+                    if self.on_grab.is_some() || slider_status.was_moved() {
+                        // maybe fire on release if `on_grab` is defined
+                        // so as to terminate the action, regardless of the actual user movement.
+                        self.maybe_fire_on_release(shell);
                     }
 
                     state.continuous_normal = self.normal_param.value.as_f32();
@@ -492,7 +552,7 @@ where
 impl<'a, Message, Renderer> From<Ramp<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Message: 'a + Clone,
+    Message: 'a,
     Renderer: 'a + self::Renderer,
     Renderer::Theme: 'a + StyleSheet,
 {

--- a/src/native/v_slider.rs
+++ b/src/native/v_slider.rs
@@ -11,7 +11,7 @@ use iced_native::{
 };
 
 use crate::core::{ModulationRange, Normal, NormalParam};
-use crate::native::{text_marks, tick_marks, VirtualSliderStatus};
+use crate::native::{text_marks, tick_marks, SliderStatus};
 use crate::style::v_slider::StyleSheet;
 
 static DEFAULT_WIDTH: u16 = 14;
@@ -33,7 +33,8 @@ where
 {
     normal_param: NormalParam,
     on_change: Box<dyn 'a + Fn(Normal) -> Message>,
-    on_release: Option<Message>,
+    on_grab: Option<Box<dyn 'a + FnMut() -> Option<Message>>>,
+    on_release: Option<Box<dyn 'a + FnMut() -> Option<Message>>>,
     scalar: f32,
     wheel_scalar: f32,
     modifier_scalar: f32,
@@ -49,7 +50,6 @@ where
 
 impl<'a, Message, Renderer> VSlider<'a, Message, Renderer>
 where
-    Message: Clone,
     Renderer: self::Renderer,
     Renderer::Theme: StyleSheet,
 {
@@ -68,6 +68,7 @@ where
         VSlider {
             normal_param,
             on_change: Box::new(on_change),
+            on_grab: None,
             on_release: None,
             scalar: DEFAULT_SCALAR,
             wheel_scalar: DEFAULT_WHEEL_SCALAR,
@@ -83,14 +84,31 @@ where
         }
     }
 
+    /// Sets the grab message of the [`VSlider`].
+    /// This is called when the mouse grabs from the slider.
+    ///
+    /// Typically, the user's interaction with the slider starts when this message is produced.
+    /// This is useful for some environments so that external changes, such as automation,
+    /// don't interfer with user's changes.
+    pub fn on_grab(
+        mut self,
+        on_grab: impl 'a + FnMut() -> Option<Message>,
+    ) -> Self {
+        self.on_grab = Some(Box::new(on_grab));
+        self
+    }
+
     /// Sets the release message of the [`VSlider`].
     /// This is called when the mouse is released from the slider.
     ///
     /// Typically, the user's interaction with the slider is finished when this message is produced.
     /// This is useful if you need to spawn a long-running task from the slider's result, where
     /// the default on_change message could create too many events.
-    pub fn on_release(mut self, on_release: Message) -> Self {
-        self.on_release = Some(on_release);
+    pub fn on_release(
+        mut self,
+        on_release: impl 'a + FnMut() -> Option<Message>,
+    ) -> Self {
+        self.on_release = Some(Box::new(on_release));
         self
     }
 
@@ -219,11 +237,10 @@ where
     fn move_virtual_slider(
         &mut self,
         state: &mut State,
-        shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
-    ) -> VirtualSliderStatus {
+    ) -> SliderStatus {
         if normal_delta.abs() < f32::EPSILON {
-            return VirtualSliderStatus::Unchanged;
+            return SliderStatus::Unchanged;
         }
 
         if state.pressed_modifiers.contains(self.modifier_keys) {
@@ -234,9 +251,27 @@ where
             Normal::new(state.continuous_normal - normal_delta);
         state.continuous_normal = self.normal_param.value.as_f32();
 
-        shell.publish((self.on_change)(self.normal_param.value));
+        SliderStatus::Moved
+    }
 
-        VirtualSliderStatus::Moved
+    fn maybe_fire_on_grab(&mut self, shell: &mut Shell<'_, Message>) {
+        if let Some(message) =
+            self.on_grab.as_mut().and_then(|on_grab| on_grab())
+        {
+            shell.publish(message);
+        }
+    }
+
+    fn fire_on_change(&self, shell: &mut Shell<'_, Message>) {
+        shell.publish((self.on_change)(self.normal_param.value));
+    }
+
+    fn maybe_fire_on_release(&mut self, shell: &mut Shell<'_, Message>) {
+        if let Some(message) =
+            self.on_release.as_mut().and_then(|on_release| on_release())
+        {
+            shell.publish(message);
+        }
     }
 }
 
@@ -245,7 +280,7 @@ where
 /// [`VSlider`]: struct.VSlider.html
 #[derive(Debug, Clone)]
 struct State {
-    dragging_status: Option<VirtualSliderStatus>,
+    dragging_status: Option<SliderStatus>,
     prev_drag_y: f32,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
@@ -278,7 +313,6 @@ impl State {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for VSlider<'a, Message, Renderer>
 where
-    Message: Clone,
     Renderer: self::Renderer,
     Renderer::Theme: StyleSheet,
 {
@@ -339,16 +373,18 @@ where
                             cursor_position.y.min(bounds.y + bounds.height)
                         };
 
-                        let slider_status = self.move_virtual_slider(
-                            state,
-                            shell,
-                            normal_delta,
-                        );
-                        state
-                            .dragging_status
-                            .as_mut()
-                            .expect("dragging_status taken")
-                            .update_with(slider_status);
+                        if self
+                            .move_virtual_slider(state, normal_delta)
+                            .was_moved()
+                        {
+                            self.fire_on_change(shell);
+
+                            state
+                                .dragging_status
+                                .as_mut()
+                                .expect("dragging_status taken")
+                                .moved();
+                        }
 
                         return event::Status::Captured;
                     }
@@ -381,11 +417,22 @@ where
                         let normal_delta = -lines * self.wheel_scalar;
 
                         if self
-                            .move_virtual_slider(state, shell, normal_delta)
+                            .move_virtual_slider(state, normal_delta)
                             .was_moved()
                         {
-                            if let Some(on_release) = self.on_release.clone() {
-                                shell.publish(on_release);
+                            if state.dragging_status.is_none() {
+                                self.maybe_fire_on_grab(shell);
+                            }
+
+                            self.fire_on_change(shell);
+
+                            if let Some(slider_status) =
+                                state.dragging_status.as_mut()
+                            {
+                                // Widget was grabbed => keep it grabbed
+                                slider_status.moved();
+                            } else {
+                                self.maybe_fire_on_release(shell);
                             }
                         }
 
@@ -401,24 +448,36 @@ where
 
                     match click.kind() {
                         mouse::click::Kind::Single => {
+                            self.maybe_fire_on_grab(shell);
+
                             state.dragging_status = Some(Default::default());
                             state.prev_drag_y = cursor_position.y;
                             state.continuous_normal =
                                 self.normal_param.value.as_f32();
                         }
                         _ => {
-                            state.dragging_status = None;
+                            // Reset to default
 
-                            self.normal_param.value = self.normal_param.default;
-                            state.continuous_normal =
-                                self.normal_param.default.as_f32();
+                            let prev_dragging_status =
+                                state.dragging_status.take();
 
-                            shell.publish((self.on_change)(
-                                self.normal_param.value,
-                            ));
+                            if self.normal_param.value
+                                != self.normal_param.default
+                            {
+                                if prev_dragging_status.is_none() {
+                                    self.maybe_fire_on_grab(shell);
+                                }
 
-                            if let Some(on_release) = self.on_release.clone() {
-                                shell.publish(on_release);
+                                self.normal_param.value =
+                                    self.normal_param.default;
+                                state.continuous_normal =
+                                    self.normal_param.default.as_f32();
+
+                                self.fire_on_change(shell);
+
+                                self.maybe_fire_on_release(shell);
+                            } else if prev_dragging_status.is_some() {
+                                self.maybe_fire_on_release(shell);
                             }
                         }
                     }
@@ -432,10 +491,10 @@ where
             | Event::Touch(touch::Event::FingerLifted { .. })
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 if let Some(slider_status) = state.dragging_status.take() {
-                    if slider_status.was_moved() {
-                        if let Some(on_release) = self.on_release.clone() {
-                            shell.publish(on_release);
-                        }
+                    if self.on_grab.is_some() || slider_status.was_moved() {
+                        // maybe fire on release if `on_grab` is defined
+                        // so as to terminate the action, regardless of the actual user movement.
+                        self.maybe_fire_on_release(shell);
                     }
 
                     state.continuous_normal = self.normal_param.value.as_f32();
@@ -540,7 +599,7 @@ where
 impl<'a, Message, Renderer> From<VSlider<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Message: 'a + Clone,
+    Message: 'a,
     Renderer: 'a + self::Renderer,
     Renderer::Theme: 'a + StyleSheet,
 {

--- a/src/native/v_slider.rs
+++ b/src/native/v_slider.rs
@@ -4,14 +4,14 @@
 
 use std::fmt::Debug;
 
+use iced_native::widget::tree::{self, Tree};
 use iced_native::{
-    event, keyboard, layout, mouse, Clipboard, Element, Event, Layout, Length,
-    Point, Rectangle, Shell, Size, Widget,
+    event, keyboard, layout, mouse, touch, Clipboard, Element, Event, Layout,
+    Length, Point, Rectangle, Shell, Size, Widget,
 };
 
 use crate::core::{ModulationRange, Normal, NormalParam};
 use crate::native::{text_marks, tick_marks};
-use crate::IntRange;
 
 static DEFAULT_WIDTH: u16 = 14;
 static DEFAULT_SCALAR: f32 = 0.9575;
@@ -26,7 +26,7 @@ static DEFAULT_MODIFIER_SCALAR: f32 = 0.02;
 /// [`VSlider`]: struct.VSlider.html
 #[allow(missing_debug_implementations)]
 pub struct VSlider<'a, Message, Renderer: self::Renderer> {
-    state: &'a mut State,
+    normal_param: NormalParam,
     on_change: Box<dyn Fn(Normal) -> Message>,
     scalar: f32,
     wheel_scalar: f32,
@@ -41,21 +41,25 @@ pub struct VSlider<'a, Message, Renderer: self::Renderer> {
     mod_range_2: Option<&'a ModulationRange>,
 }
 
-impl<'a, Message, Renderer: self::Renderer> VSlider<'a, Message, Renderer> {
+impl<'a, Message, Renderer> VSlider<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
     /// Creates a new [`VSlider`].
     ///
     /// It expects:
-    ///   * the local [`State`] of the [`VSlider`]
+    ///   * the [`NormalParam`] of the [`VSlider`]
     ///   * a function that will be called when the [`VSlider`] is dragged.
     ///
-    /// [`State`]: struct.State.html
+    /// [`NormalParam`]: struct.NormalParam.html
     /// [`VSlider`]: struct.VSlider.html
-    pub fn new<F>(state: &'a mut State, on_change: F) -> Self
+    pub fn new<F>(normal_param: NormalParam, on_change: F) -> Self
     where
         F: 'static + Fn(Normal) -> Message,
     {
         VSlider {
-            state,
+            normal_param,
             on_change: Box::new(on_change),
             scalar: DEFAULT_SCALAR,
             wheel_scalar: DEFAULT_WHEEL_SCALAR,
@@ -192,26 +196,19 @@ impl<'a, Message, Renderer: self::Renderer> VSlider<'a, Message, Renderer> {
 
     fn move_virtual_slider(
         &mut self,
-        messages: &mut Shell<'_, Message>,
+        state: &mut State,
+        shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
     ) {
-        if self.state.pressed_modifiers.contains(self.modifier_keys) {
+        if state.pressed_modifiers.contains(self.modifier_keys) {
             normal_delta *= self.modifier_scalar;
         }
 
-        let mut normal = self.state.continuous_normal - normal_delta;
+        self.normal_param.value =
+            Normal::new(state.continuous_normal - normal_delta);
+        state.continuous_normal = self.normal_param.value.as_f32();
 
-        if normal < 0.0 {
-            normal = 0.0;
-        } else if normal > 1.0 {
-            normal = 1.0;
-        }
-
-        self.state.continuous_normal = normal;
-
-        self.state.normal_param.value = normal.into();
-
-        messages.publish((self.on_change)(self.state.normal_param.value));
+        shell.publish((self.on_change)(self.normal_param.value));
     }
 }
 
@@ -219,8 +216,7 @@ impl<'a, Message, Renderer: self::Renderer> VSlider<'a, Message, Renderer> {
 ///
 /// [`VSlider`]: struct.VSlider.html
 #[derive(Debug, Clone)]
-pub struct State {
-    normal_param: NormalParam,
+struct State {
     is_dragging: bool,
     prev_drag_y: f32,
     continuous_normal: f32,
@@ -234,74 +230,37 @@ impl State {
     /// Creates a new [`VSlider`] state.
     ///
     /// It expects:
-    /// * a [`NormalParam`] to assign to this widget
+    /// * current [`Normal`] value for the [`VSlider`]
     ///
+    /// [`Normal`]: ../../core/normal/struct.Normal.html
     /// [`VSlider`]: struct.VSlider.html
-    pub fn new(normal_param: NormalParam) -> Self {
+    fn new(normal: Normal) -> Self {
         Self {
-            normal_param,
             is_dragging: false,
             prev_drag_y: 0.0,
-            continuous_normal: normal_param.value.as_f32(),
+            continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
             tick_marks_cache: Default::default(),
             text_marks_cache: Default::default(),
         }
     }
-
-    /// Set the normalized value of the [`VSlider`].
-    pub fn set_normal(&mut self, normal: Normal) {
-        self.normal_param.value = normal;
-        self.continuous_normal = normal.into();
-    }
-
-    /// Get the normalized value of the [`VSlider`].
-    pub fn normal(&self) -> Normal {
-        self.normal_param.value
-    }
-
-    /// Set the normalized default value of the [`VSlider`].
-    pub fn set_default(&mut self, normal: Normal) {
-        self.normal_param.default = normal;
-    }
-
-    /// Get the normalized default value of the [`VSlider`].
-    pub fn default(&self) -> Normal {
-        self.normal_param.default
-    }
-
-    /// Snap the visible value of the [`VSlider`] to the nearest value
-    /// in the integer range.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use iced_audio::{v_slider, IntRange};
-    ///
-    /// let mut state = v_slider::State::new(Default::default());
-    /// let int_range = IntRange::new(0, 10);
-    ///
-    /// state.snap_visible_to(&int_range);
-    ///
-    /// ```
-    pub fn snap_visible_to(&mut self, range: &IntRange) {
-        self.normal_param.value = range.snapped(self.normal_param.value);
-    }
-
-    /// Is the [`VSlider`] currently in the dragging state?
-    ///
-    /// [`VSlider`]: struct.VSlider.html
-    pub fn is_dragging(&self) -> bool {
-        self.is_dragging
-    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for VSlider<'a, Message, Renderer>
 where
+    Message: Clone,
     Renderer: self::Renderer,
 {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::new(self.normal_param.value))
+    }
+
     fn width(&self) -> Length {
         Length::Shrink
     }
@@ -324,118 +283,121 @@ where
 
     fn on_event(
         &mut self,
+        state: &mut Tree,
         event: Event,
         layout: Layout<'_>,
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Shell<'_, Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
+        let state = state.state.downcast_mut::<State>();
+
         match event {
-            Event::Mouse(mouse_event) => match mouse_event {
-                mouse::Event::CursorMoved { .. } => {
-                    if self.state.is_dragging {
-                        let bounds_height = layout.bounds().height;
+            Event::Mouse(mouse::Event::CursorMoved { .. })
+            | Event::Touch(touch::Event::FingerMoved { .. }) => {
+                if state.is_dragging {
+                    let bounds_height = layout.bounds().height;
+                    if bounds_height > 0.0 {
+                        let normal_delta = (cursor_position.y
+                            - state.prev_drag_y)
+                            / bounds_height
+                            * self.scalar;
 
-                        if bounds_height > 0.0 {
-                            let normal_delta = (cursor_position.y
-                                - self.state.prev_drag_y)
-                                / bounds_height
-                                * self.scalar;
+                        state.prev_drag_y = cursor_position.y;
 
-                            self.state.prev_drag_y = cursor_position.y;
-
-                            self.move_virtual_slider(messages, normal_delta);
-
-                            return event::Status::Captured;
-                        }
-                    }
-                }
-                mouse::Event::WheelScrolled { delta } => {
-                    if self.wheel_scalar == 0.0 {
-                        return event::Status::Ignored;
-                    }
-
-                    if layout.bounds().contains(cursor_position) {
-                        let lines = match delta {
-                            iced_native::mouse::ScrollDelta::Lines {
-                                y,
-                                ..
-                            } => y,
-                            iced_native::mouse::ScrollDelta::Pixels {
-                                y,
-                                ..
-                            } => {
-                                if y > 0.0 {
-                                    1.0
-                                } else if y < 0.0 {
-                                    -1.0
-                                } else {
-                                    0.0
-                                }
-                            }
-                        };
-
-                        if lines != 0.0 {
-                            let normal_delta = -lines * self.wheel_scalar;
-
-                            self.move_virtual_slider(messages, normal_delta);
-
-                            return event::Status::Captured;
-                        }
-                    }
-                }
-                mouse::Event::ButtonPressed(mouse::Button::Left) => {
-                    if layout.bounds().contains(cursor_position) {
-                        let click = mouse::Click::new(
-                            cursor_position,
-                            self.state.last_click,
-                        );
-
-                        match click.kind() {
-                            mouse::click::Kind::Single => {
-                                self.state.is_dragging = true;
-                                self.state.prev_drag_y = cursor_position.y;
-                            }
-                            _ => {
-                                self.state.is_dragging = false;
-
-                                self.state.normal_param.value =
-                                    self.state.normal_param.default;
-
-                                messages.publish((self.on_change)(
-                                    self.state.normal_param.value,
-                                ));
-                            }
-                        }
-
-                        self.state.last_click = Some(click);
+                        self.move_virtual_slider(state, shell, normal_delta);
 
                         return event::Status::Captured;
                     }
                 }
-                mouse::Event::ButtonReleased(mouse::Button::Left) => {
-                    self.state.is_dragging = false;
-                    self.state.continuous_normal =
-                        self.state.normal_param.value.as_f32();
+            }
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if self.wheel_scalar == 0.0 {
+                    return event::Status::Ignored;
+                }
+
+                if layout.bounds().contains(cursor_position) {
+                    let lines = match delta {
+                        iced_native::mouse::ScrollDelta::Lines {
+                            y, ..
+                        } => y,
+                        iced_native::mouse::ScrollDelta::Pixels {
+                            y, ..
+                        } => {
+                            if y > 0.0 {
+                                1.0
+                            } else if y < 0.0 {
+                                -1.0
+                            } else {
+                                0.0
+                            }
+                        }
+                    };
+
+                    if lines != 0.0 {
+                        let normal_delta = -lines * self.wheel_scalar;
+
+                        self.move_virtual_slider(state, shell, normal_delta);
+
+                        return event::Status::Captured;
+                    }
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if layout.bounds().contains(cursor_position) {
+                    let click =
+                        mouse::Click::new(cursor_position, state.last_click);
+
+                    match click.kind() {
+                        mouse::click::Kind::Single => {
+                            state.is_dragging = true;
+                            state.prev_drag_y = cursor_position.y;
+                            state.continuous_normal =
+                                self.normal_param.value.as_f32();
+                        }
+                        _ => {
+                            state.is_dragging = false;
+
+                            self.normal_param.value = self.normal_param.default;
+                            state.continuous_normal =
+                                self.normal_param.default.as_f32();
+
+                            shell.publish((self.on_change)(
+                                self.normal_param.value,
+                            ));
+                        }
+                    }
+
+                    state.last_click = Some(click);
 
                     return event::Status::Captured;
                 }
-                _ => {}
-            },
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. })
+            | Event::Touch(touch::Event::FingerLost { .. }) => {
+                if state.is_dragging {
+                    state.is_dragging = false;
+                    state.continuous_normal = self.normal_param.value.as_f32();
+
+                    return event::Status::Captured;
+                }
+            }
             Event::Keyboard(keyboard_event) => match keyboard_event {
                 keyboard::Event::KeyPressed { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::KeyReleased { modifiers, .. } => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
                 keyboard::Event::ModifiersChanged(modifiers) => {
-                    self.state.pressed_modifiers = modifiers;
+                    state.pressed_modifiers = modifiers;
 
                     return event::Status::Captured;
                 }
@@ -449,24 +411,27 @@ where
 
     fn draw(
         &self,
+        state: &Tree,
         renderer: &mut Renderer,
+        _theme: &Renderer::Theme,
         _style: &iced_native::renderer::Style,
         layout: Layout<'_>,
         cursor_position: Point,
         _viewport: &Rectangle,
     ) {
+        let state = state.state.downcast_ref::<State>();
         renderer.draw(
             layout.bounds(),
             cursor_position,
-            self.state.normal_param.value,
-            self.state.is_dragging,
+            self.normal_param.value,
+            state.is_dragging,
             self.mod_range_1,
             self.mod_range_2,
             self.tick_marks,
             self.text_marks,
             &self.style,
-            &self.state.tick_marks_cache,
-            &self.state.text_marks_cache,
+            &state.tick_marks_cache,
+            &state.text_marks_cache,
         )
     }
 }
@@ -513,8 +478,8 @@ pub trait Renderer: iced_native::Renderer {
 impl<'a, Message, Renderer> From<VSlider<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
+    Message: 'a + Clone,
     Renderer: 'a + self::Renderer,
-    Message: 'a,
 {
     fn from(
         v_slider: VSlider<'a, Message, Renderer>,

--- a/src/native/v_slider.rs
+++ b/src/native/v_slider.rs
@@ -11,7 +11,7 @@ use iced_native::{
 };
 
 use crate::core::{ModulationRange, Normal, NormalParam};
-use crate::native::{text_marks, tick_marks};
+use crate::native::{text_marks, tick_marks, VirtualSliderStatus};
 use crate::style::v_slider::StyleSheet;
 
 static DEFAULT_WIDTH: u16 = 14;
@@ -33,6 +33,7 @@ where
 {
     normal_param: NormalParam,
     on_change: Box<dyn 'a + Fn(Normal) -> Message>,
+    on_release: Option<Message>,
     scalar: f32,
     wheel_scalar: f32,
     modifier_scalar: f32,
@@ -67,6 +68,7 @@ where
         VSlider {
             normal_param,
             on_change: Box::new(on_change),
+            on_release: None,
             scalar: DEFAULT_SCALAR,
             wheel_scalar: DEFAULT_WHEEL_SCALAR,
             modifier_scalar: DEFAULT_MODIFIER_SCALAR,
@@ -79,6 +81,17 @@ where
             mod_range_1: None,
             mod_range_2: None,
         }
+    }
+
+    /// Sets the release message of the [`VSlider`].
+    /// This is called when the mouse is released from the slider.
+    ///
+    /// Typically, the user's interaction with the slider is finished when this message is produced.
+    /// This is useful if you need to spawn a long-running task from the slider's result, where
+    /// the default on_change message could create too many events.
+    pub fn on_release(mut self, on_release: Message) -> Self {
+        self.on_release = Some(on_release);
+        self
     }
 
     /// Sets the width of the [`VSlider`].
@@ -208,9 +221,9 @@ where
         state: &mut State,
         shell: &mut Shell<'_, Message>,
         mut normal_delta: f32,
-    ) {
+    ) -> VirtualSliderStatus {
         if normal_delta.abs() < f32::EPSILON {
-            return;
+            return VirtualSliderStatus::Unchanged;
         }
 
         if state.pressed_modifiers.contains(self.modifier_keys) {
@@ -222,6 +235,8 @@ where
         state.continuous_normal = self.normal_param.value.as_f32();
 
         shell.publish((self.on_change)(self.normal_param.value));
+
+        VirtualSliderStatus::Moved
     }
 }
 
@@ -230,7 +245,7 @@ where
 /// [`VSlider`]: struct.VSlider.html
 #[derive(Debug, Clone)]
 struct State {
-    is_dragging: bool,
+    dragging_status: Option<VirtualSliderStatus>,
     prev_drag_y: f32,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
@@ -249,7 +264,7 @@ impl State {
     /// [`VSlider`]: struct.VSlider.html
     fn new(normal: Normal) -> Self {
         Self {
-            is_dragging: false,
+            dragging_status: None,
             prev_drag_y: 0.0,
             continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
@@ -310,7 +325,7 @@ where
         match event {
             Event::Mouse(mouse::Event::CursorMoved { .. })
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
-                if state.is_dragging {
+                if state.dragging_status.is_some() {
                     let bounds = layout.bounds();
                     if bounds.height > 0.0 {
                         let normal_delta = (cursor_position.y
@@ -324,7 +339,16 @@ where
                             cursor_position.y.min(bounds.y + bounds.height)
                         };
 
-                        self.move_virtual_slider(state, shell, normal_delta);
+                        let slider_status = self.move_virtual_slider(
+                            state,
+                            shell,
+                            normal_delta,
+                        );
+                        state
+                            .dragging_status
+                            .as_mut()
+                            .expect("dragging_status taken")
+                            .update_with(slider_status);
 
                         return event::Status::Captured;
                     }
@@ -356,7 +380,14 @@ where
                     if lines != 0.0 {
                         let normal_delta = -lines * self.wheel_scalar;
 
-                        self.move_virtual_slider(state, shell, normal_delta);
+                        if self
+                            .move_virtual_slider(state, shell, normal_delta)
+                            .was_moved()
+                        {
+                            if let Some(on_release) = self.on_release.clone() {
+                                shell.publish(on_release);
+                            }
+                        }
 
                         return event::Status::Captured;
                     }
@@ -370,13 +401,13 @@ where
 
                     match click.kind() {
                         mouse::click::Kind::Single => {
-                            state.is_dragging = true;
+                            state.dragging_status = Some(Default::default());
                             state.prev_drag_y = cursor_position.y;
                             state.continuous_normal =
                                 self.normal_param.value.as_f32();
                         }
                         _ => {
-                            state.is_dragging = false;
+                            state.dragging_status = None;
 
                             self.normal_param.value = self.normal_param.default;
                             state.continuous_normal =
@@ -385,6 +416,10 @@ where
                             shell.publish((self.on_change)(
                                 self.normal_param.value,
                             ));
+
+                            if let Some(on_release) = self.on_release.clone() {
+                                shell.publish(on_release);
+                            }
                         }
                     }
 
@@ -396,8 +431,13 @@ where
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerLifted { .. })
             | Event::Touch(touch::Event::FingerLost { .. }) => {
-                if state.is_dragging {
-                    state.is_dragging = false;
+                if let Some(slider_status) = state.dragging_status.take() {
+                    if slider_status.was_moved() {
+                        if let Some(on_release) = self.on_release.clone() {
+                            shell.publish(on_release);
+                        }
+                    }
+
                     state.continuous_normal = self.normal_param.value.as_f32();
 
                     return event::Status::Captured;
@@ -442,7 +482,7 @@ where
             layout.bounds(),
             cursor_position,
             self.normal_param.value,
-            state.is_dragging,
+            state.dragging_status.is_some(),
             self.mod_range_1,
             self.mod_range_2,
             self.tick_marks,
@@ -483,7 +523,7 @@ where
         bounds: Rectangle,
         cursor_position: Point,
         normal: Normal,
-        is_dragging: bool,
+        dragging_status: bool,
         mod_range_1: Option<&ModulationRange>,
         mod_range_2: Option<&ModulationRange>,
         tick_marks: Option<&tick_marks::Group>,

--- a/src/native/v_slider.rs
+++ b/src/native/v_slider.rs
@@ -12,6 +12,7 @@ use iced_native::{
 
 use crate::core::{ModulationRange, Normal, NormalParam};
 use crate::native::{text_marks, tick_marks};
+use crate::style::v_slider::StyleSheet;
 
 static DEFAULT_WIDTH: u16 = 14;
 static DEFAULT_SCALAR: f32 = 0.9575;
@@ -25,16 +26,20 @@ static DEFAULT_MODIFIER_SCALAR: f32 = 0.02;
 /// [`NormalParam`]: ../../core/normal_param/struct.NormalParam.html
 /// [`VSlider`]: struct.VSlider.html
 #[allow(missing_debug_implementations)]
-pub struct VSlider<'a, Message, Renderer: self::Renderer> {
+pub struct VSlider<'a, Message, Renderer>
+where
+    Renderer: self::Renderer,
+    Renderer::Theme: StyleSheet,
+{
     normal_param: NormalParam,
-    on_change: Box<dyn Fn(Normal) -> Message>,
+    on_change: Box<dyn 'a + Fn(Normal) -> Message>,
     scalar: f32,
     wheel_scalar: f32,
     modifier_scalar: f32,
     modifier_keys: keyboard::Modifiers,
     width: Length,
     height: Length,
-    style: Renderer::Style,
+    style: <Renderer::Theme as StyleSheet>::Style,
     tick_marks: Option<&'a tick_marks::Group>,
     text_marks: Option<&'a text_marks::Group>,
     mod_range_1: Option<&'a ModulationRange>,
@@ -45,6 +50,7 @@ impl<'a, Message, Renderer> VSlider<'a, Message, Renderer>
 where
     Message: Clone,
     Renderer: self::Renderer,
+    Renderer::Theme: StyleSheet,
 {
     /// Creates a new [`VSlider`].
     ///
@@ -67,7 +73,7 @@ where
             modifier_keys: keyboard::Modifiers::CTRL,
             width: Length::from(Length::Units(DEFAULT_WIDTH)),
             height: Length::Fill,
-            style: Renderer::Style::default(),
+            style: Default::default(),
             tick_marks: None,
             text_marks: None,
             mod_range_1: None,
@@ -96,7 +102,10 @@ where
     /// Sets the style of the [`VSlider`].
     ///
     /// [`VSlider`]: struct.VSlider.html
-    pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
+    pub fn style(
+        mut self,
+        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
+    ) -> Self {
         self.style = style.into();
         self
     }
@@ -256,6 +265,7 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
 where
     Message: Clone,
     Renderer: self::Renderer,
+    Renderer::Theme: StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State>()
@@ -421,7 +431,7 @@ where
         &self,
         state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        theme: &Renderer::Theme,
         _style: &iced_native::renderer::Style,
         layout: Layout<'_>,
         cursor_position: Point,
@@ -437,6 +447,7 @@ where
             self.mod_range_2,
             self.tick_marks,
             self.text_marks,
+            theme,
             &self.style,
             &state.tick_marks_cache,
             &state.text_marks_cache,
@@ -450,10 +461,10 @@ where
 /// able to use a [`VSlider`] in your user interface.
 ///
 /// [`VSlider`]: struct.VSlider.html
-pub trait Renderer: iced_native::Renderer {
-    /// The style supported by this renderer.
-    type Style: Default;
-
+pub trait Renderer: iced_native::Renderer
+where
+    Self::Theme: StyleSheet,
+{
     /// Draws a [`VSlider`].
     ///
     /// It receives:
@@ -477,7 +488,10 @@ pub trait Renderer: iced_native::Renderer {
         mod_range_2: Option<&ModulationRange>,
         tick_marks: Option<&tick_marks::Group>,
         text_marks: Option<&text_marks::Group>,
-        style: &Self::Style,
+        style_sheet: &dyn StyleSheet<
+            Style = <Self::Theme as StyleSheet>::Style,
+        >,
+        style: &<Self::Theme as StyleSheet>::Style,
         tick_marks_cache: &crate::tick_marks::PrimitiveCache,
         text_marks_cache: &crate::text_marks::PrimitiveCache,
     );
@@ -488,6 +502,7 @@ impl<'a, Message, Renderer> From<VSlider<'a, Message, Renderer>>
 where
     Message: 'a + Clone,
     Renderer: 'a + self::Renderer,
+    Renderer::Theme: 'a + StyleSheet,
 {
     fn from(
         v_slider: VSlider<'a, Message, Renderer>,

--- a/src/style/h_slider.rs
+++ b/src/style/h_slider.rs
@@ -38,12 +38,14 @@ pub struct ClassicRail {
 ///
 /// [`Style`]: enum.Style.html
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-/// [`Handle`]: https://docs.rs/iced/0.1.1/iced/widget/image/struct.Handle.html
+/// [`Handle`]: https://docs.rs/iced/latest/iced/pure/widget/image/struct.Handle.html
 #[derive(Debug, Clone)]
 pub struct TextureStyle {
     /// The rail style
     pub rail: ClassicRail,
     /// The [`Handle`] to the image texture
+    ///
+    /// [`Handle`]: https://docs.rs/iced/latest/iced/pure/widget/image/struct.Handle.html
     pub image_handle: image::Handle,
     /// The effective width of the handle (not including any padding on the texture)
     pub handle_width: u16,

--- a/src/style/h_slider.rs
+++ b/src/style/h_slider.rs
@@ -4,14 +4,13 @@
 
 use iced_native::{image, Color, Rectangle};
 
-use crate::core::Offset;
 use crate::style::{default_colors, text_marks, tick_marks};
 
 /// The appearance of an [`HSlider`].
 ///
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
 #[derive(Debug, Clone)]
-pub enum Style {
+pub enum Appearance {
     /// uses an image texture for the handle
     Texture(TextureStyle),
     /// modeled after hardware sliders
@@ -34,9 +33,9 @@ pub struct ClassicRail {
     pub rail_padding: f32,
 }
 
-/// A [`Style`] for an [`HSlider`] that uses an image texture for the handle
+/// An [`Appearance`] for an [`HSlider`] that uses an image texture for the handle
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
 /// [`Handle`]: https://docs.rs/iced/latest/iced/pure/widget/image/struct.Handle.html
 #[derive(Debug, Clone)]
@@ -54,9 +53,9 @@ pub struct TextureStyle {
     pub image_bounds: Rectangle,
 }
 
-/// A classic [`Style`] for an [`HSlider`], modeled after hardware sliders
+/// A classic [`Appearance`] for an [`HSlider`], modeled after hardware sliders
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
 /// [`ClassicHandle`]: struct.ClassicHandle.html
 #[derive(Debug, Clone)]
@@ -65,6 +64,19 @@ pub struct ClassicStyle {
     pub rail: ClassicRail,
     /// a `ClassicHandle` defining the style of the handle
     pub handle: ClassicHandle,
+}
+
+impl Default for ClassicStyle {
+    fn default() -> Self {
+        ClassicStyle {
+            rail: ClassicRail {
+                rail_colors: default_colors::SLIDER_RAIL,
+                rail_widths: (1.0, 1.0),
+                rail_padding: 12.0,
+            },
+            handle: ClassicHandle::default(),
+        }
+    }
 }
 
 /// The [`ClassicStyle`] appearance of the handle of an [`HSlider`]
@@ -89,10 +101,24 @@ pub struct ClassicHandle {
     pub border_color: Color,
 }
 
-/// A modern [`Style`] for an [`HSlider`]. It is composed of a background
+impl Default for ClassicHandle {
+    fn default() -> Self {
+        ClassicHandle {
+            color: default_colors::LIGHT_BACK,
+            width: 34,
+            notch_width: 4.0,
+            notch_color: default_colors::BORDER,
+            border_radius: 2.0,
+            border_color: default_colors::BORDER,
+            border_width: 1.0,
+        }
+    }
+}
+
+/// A modern [`Appearance`] for an [`HSlider`]. It is composed of a background
 /// rectangle and a rectangular handle.
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
 #[derive(Debug, Clone, Copy)]
 pub struct RectStyle {
@@ -115,11 +141,11 @@ pub struct RectStyle {
     pub handle_filled_gap: f32,
 }
 
-/// A modern [`Style`] for an [`HSlider`]. It is composed of a background
+/// A modern [`Appearance`] for an [`HSlider`]. It is composed of a background
 /// rectangle and a rectangular handle. It has different colors for left, right,
 /// and center values.
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
 #[derive(Debug, Clone, Copy)]
 pub struct RectBipolarStyle {
@@ -210,6 +236,7 @@ pub struct ModRangeStyle {
     /// `start`.
     pub filled_inverse_color: Color,
 }
+
 /// Style of tick marks for an [`HSlider`].
 ///
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
@@ -236,27 +263,30 @@ pub struct TextMarksStyle {
 ///
 /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
 pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
     /// Produces the style of an active [`HSlider`].
     ///
     /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-    fn active(&self) -> Style;
+    fn active(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a hovered [`HSlider`].
     ///
     /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-    fn hovered(&self) -> Style;
+    fn hovered(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of an [`HSlider`] that is being dragged.
     ///
     /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-    fn dragging(&self) -> Style;
+    fn dragging(&self, style: &Self::Style) -> Appearance;
 
     /// The style of tick marks for an [`HSlider`]
     ///
     /// For no tick marks, don't override this or set this to return `None`.
     ///
     /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-    fn tick_marks_style(&self) -> Option<TickMarksStyle> {
+    fn tick_marks_style(&self, _style: &Self::Style) -> Option<TickMarksStyle> {
         None
     }
 
@@ -266,7 +296,7 @@ pub trait StyleSheet {
     ///
     /// [`ModulationRange`]: ../../core/struct.ModulationRange.html
     /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-    fn mod_range_style(&self) -> Option<ModRangeStyle> {
+    fn mod_range_style(&self, _style: &Self::Style) -> Option<ModRangeStyle> {
         None
     }
 
@@ -276,7 +306,7 @@ pub trait StyleSheet {
     ///
     /// [`ModulationRange`]: ../../core/struct.ModulationRange.html
     /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-    fn mod_range_style_2(&self) -> Option<ModRangeStyle> {
+    fn mod_range_style_2(&self, _style: &Self::Style) -> Option<ModRangeStyle> {
         None
     }
 
@@ -285,103 +315,7 @@ pub trait StyleSheet {
     /// For no text marks, don't override this or set this to return `None`.
     ///
     /// [`HSlider`]: ../../native/h_slider/struct.HSlider.html
-    fn text_marks_style(&self) -> Option<TextMarksStyle> {
+    fn text_marks_style(&self, _style: &Self::Style) -> Option<TextMarksStyle> {
         None
-    }
-}
-
-struct Default;
-impl Default {
-    const ACTIVE_STYLE: ClassicStyle = ClassicStyle {
-        rail: ClassicRail {
-            rail_colors: default_colors::SLIDER_RAIL,
-            rail_widths: (1.0, 1.0),
-            rail_padding: 12.0,
-        },
-        handle: ClassicHandle {
-            color: default_colors::LIGHT_BACK,
-            width: 34,
-            notch_width: 4.0,
-            notch_color: default_colors::BORDER,
-            border_radius: 2.0,
-            border_color: default_colors::BORDER,
-            border_width: 1.0,
-        },
-    };
-}
-impl StyleSheet for Default {
-    fn active(&self) -> Style {
-        Style::Classic(Self::ACTIVE_STYLE)
-    }
-
-    fn hovered(&self) -> Style {
-        Style::Classic(ClassicStyle {
-            handle: ClassicHandle {
-                color: default_colors::LIGHT_BACK_HOVER,
-                ..Self::ACTIVE_STYLE.handle
-            },
-            ..Self::ACTIVE_STYLE
-        })
-    }
-
-    fn dragging(&self) -> Style {
-        Style::Classic(ClassicStyle {
-            handle: ClassicHandle {
-                color: default_colors::LIGHT_BACK_DRAG,
-                ..Self::ACTIVE_STYLE.handle
-            },
-            ..Self::ACTIVE_STYLE
-        })
-    }
-
-    fn tick_marks_style(&self) -> Option<TickMarksStyle> {
-        Some(TickMarksStyle {
-            style: tick_marks::Style {
-                tier_1: tick_marks::Shape::Line {
-                    length: 24.0,
-                    width: 2.0,
-                    color: default_colors::TICK_TIER_1,
-                },
-                tier_2: tick_marks::Shape::Line {
-                    length: 22.0,
-                    width: 1.0,
-                    color: default_colors::TICK_TIER_2,
-                },
-                tier_3: tick_marks::Shape::Line {
-                    length: 18.0,
-                    width: 1.0,
-                    color: default_colors::TICK_TIER_3,
-                },
-            },
-            placement: tick_marks::Placement::Center {
-                offset: Offset::ZERO,
-                fill_length: false,
-            },
-        })
-    }
-
-    fn text_marks_style(&self) -> Option<TextMarksStyle> {
-        Some(TextMarksStyle {
-            style: text_marks::Style::default(),
-            placement: text_marks::Placement::RightOrBottom {
-                inside: false,
-                offset: Offset { x: 0.0, y: 7.0 },
-            },
-        })
-    }
-}
-
-impl std::default::Default for Box<dyn StyleSheet> {
-    fn default() -> Self {
-        Box::new(Default)
-    }
-}
-
-impl<T> From<T> for Box<dyn StyleSheet>
-where
-    T: 'static + StyleSheet,
-{
-    fn from(style: T) -> Self {
-        Box::new(style)
     }
 }

--- a/src/style/knob.rs
+++ b/src/style/knob.rs
@@ -14,7 +14,7 @@ use crate::KnobAngleRange;
 ///
 /// [`Knob`]: ../../native/knob/struct.Knob.html
 #[derive(Debug, Clone)]
-pub enum Style {
+pub enum Appearance {
     //Texture(TextureStyle),
     /// A classic circular style
     Circle(CircleStyle),
@@ -26,9 +26,9 @@ pub enum Style {
 }
 
 /*
-/// A [`Style`] for a [`Knob`] that uses an image texture for the knob
+/// An [`Appearance`] for a [`Knob`] that uses an image texture for the knob
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`Knob`]: ../../native/knob/struct.Knob.html
 /// [`Handle`]: https://docs.rs/iced/0.1.1/iced/widget/image/struct.Handle.html
 #[derive(Debug, Clone)]
@@ -109,9 +109,9 @@ pub enum NotchShape {
     Line(LineNotch),
 }
 
-/// A classic circular [`Style`] of a [`Knob`]
+/// A classic circular [`Appearance`] of a [`Knob`]
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`Knob`]: ../../native/knob/struct.Knob.html
 #[derive(Debug, Clone)]
 pub struct CircleStyle {
@@ -125,9 +125,26 @@ pub struct CircleStyle {
     pub notch: NotchShape,
 }
 
-/// A modern arc [`Style`] of a [`Knob`]
+impl Default for CircleStyle {
+    fn default() -> Self {
+        CircleStyle {
+            color: default_colors::LIGHT_BACK,
+            border_width: 1.0,
+            border_color: default_colors::BORDER,
+            notch: NotchShape::Circle(CircleNotch {
+                color: default_colors::BORDER,
+                border_width: 0.0,
+                border_color: Color::TRANSPARENT,
+                diameter: StyleLength::Scaled(0.17),
+                offset: StyleLength::Scaled(0.15),
+            }),
+        }
+    }
+}
+
+/// A modern arc [`Appearance`] of a [`Knob`]
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`Knob`]: ../../native/knob/struct.Knob.html
 #[derive(Debug, Clone)]
 pub struct ArcStyle {
@@ -143,11 +160,11 @@ pub struct ArcStyle {
     pub cap: LineCap,
 }
 
-/// A modern arc [`Style`] of a [`Knob`].
+/// A modern arc [`Appearance`] of a [`Knob`].
 /// It can display different colors for left, right, and center positions. The filled arc
 /// color draws from the center position.
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`Knob`]: ../../native/knob/struct.Knob.html
 #[derive(Debug, Clone)]
 pub struct ArcBipolarStyle {
@@ -259,26 +276,29 @@ impl std::default::Default for TextMarksStyle {
 ///
 /// [`Knob`]: ../../native/knob/struct.Knob.html
 pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
     /// Produces the style of an active [`Knob`].
     ///
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn active(&self) -> Style;
+    fn active(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a hovered [`Knob`].
     ///
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn hovered(&self) -> Style;
+    fn hovered(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a [`Knob`] that is being dragged.
     ///
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn dragging(&self) -> Style;
+    fn dragging(&self, style: &Self::Style) -> Appearance;
 
     /// a [`KnobAngleRange`] that defines the minimum and maximum angle that the
     /// knob rotates
     ///
     /// [`KnobAngleRange`]: struct.KnobAngleRange.html
-    fn angle_range(&self) -> KnobAngleRange {
+    fn angle_range(&self, _style: &Self::Style) -> KnobAngleRange {
         KnobAngleRange::default()
     }
 
@@ -288,7 +308,7 @@ pub trait StyleSheet {
     ///
     /// [`TickMarkGroup`]: ../../core/tick_marks/struct.TickMarkGroup.html
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn tick_marks_style(&self) -> Option<TickMarksStyle> {
+    fn tick_marks_style(&self, _style: &Self::Style) -> Option<TickMarksStyle> {
         None
     }
 
@@ -297,7 +317,7 @@ pub trait StyleSheet {
     /// For no value arc, don't override this or set this to return `None`.
     ///
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn value_arc_style(&self) -> Option<ValueArcStyle> {
+    fn value_arc_style(&self, _style: &Self::Style) -> Option<ValueArcStyle> {
         None
     }
 
@@ -307,7 +327,10 @@ pub trait StyleSheet {
     ///
     /// [`ModulationRange`]: ../../core/struct.ModulationRange.html
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn mod_range_arc_style(&self) -> Option<ModRangeArcStyle> {
+    fn mod_range_arc_style(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<ModRangeArcStyle> {
         None
     }
 
@@ -317,7 +340,10 @@ pub trait StyleSheet {
     ///
     /// [`ModulationRange`]: ../../core/struct.ModulationRange.html
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn mod_range_arc_style_2(&self) -> Option<ModRangeArcStyle> {
+    fn mod_range_arc_style_2(
+        &self,
+        _style: &Self::Style,
+    ) -> Option<ModRangeArcStyle> {
         None
     }
 
@@ -327,84 +353,7 @@ pub trait StyleSheet {
     ///
     /// [`TextMarkGroup`]: ../../core/text_marks/struct.TextMarkGroup.html
     /// [`Knob`]: ../../native/knob/struct.Knob.html
-    fn text_marks_style(&self) -> Option<TextMarksStyle> {
+    fn text_marks_style(&self, _style: &Self::Style) -> Option<TextMarksStyle> {
         None
-    }
-}
-
-struct Default;
-impl Default {
-    const ACTIVE_CIRCLE_STYLE: CircleStyle = CircleStyle {
-        color: default_colors::LIGHT_BACK,
-        border_width: 1.0,
-        border_color: default_colors::BORDER,
-        notch: NotchShape::Circle(CircleNotch {
-            color: default_colors::BORDER,
-            border_width: 0.0,
-            border_color: Color::TRANSPARENT,
-            diameter: StyleLength::Scaled(0.17),
-            offset: StyleLength::Scaled(0.15),
-        }),
-    };
-}
-impl StyleSheet for Default {
-    fn active(&self) -> Style {
-        Style::Circle(Self::ACTIVE_CIRCLE_STYLE)
-    }
-
-    #[allow(irrefutable_let_patterns)]
-    fn hovered(&self) -> Style {
-        Style::Circle(CircleStyle {
-            color: default_colors::KNOB_BACK_HOVER,
-            ..Self::ACTIVE_CIRCLE_STYLE
-        })
-    }
-
-    fn dragging(&self) -> Style {
-        self.hovered()
-    }
-
-    fn tick_marks_style(&self) -> Option<TickMarksStyle> {
-        Some(TickMarksStyle {
-            style: tick_marks::Style {
-                tier_1: tick_marks::Shape::Circle {
-                    diameter: 4.0,
-                    color: default_colors::TICK_TIER_1,
-                },
-                tier_2: tick_marks::Shape::Circle {
-                    diameter: 2.0,
-                    color: default_colors::TICK_TIER_2,
-                },
-                tier_3: tick_marks::Shape::Circle {
-                    diameter: 2.0,
-                    color: default_colors::TICK_TIER_3,
-                },
-            },
-            offset: 3.5,
-        })
-    }
-
-    fn text_marks_style(&self) -> Option<TextMarksStyle> {
-        Some(TextMarksStyle {
-            style: text_marks::Style::default(),
-            offset: 14.0,
-            h_char_offset: 3.0,
-            v_offset: -0.75,
-        })
-    }
-}
-
-impl std::default::Default for Box<dyn StyleSheet> {
-    fn default() -> Self {
-        Box::new(Default)
-    }
-}
-
-impl<T> From<T> for Box<dyn StyleSheet>
-where
-    T: 'static + StyleSheet,
-{
-    fn from(style: T) -> Self {
-        Box::new(style)
     }
 }

--- a/src/style/knob.rs
+++ b/src/style/knob.rs
@@ -5,7 +5,7 @@
 use iced_native::Color;
 //use iced_native::image;
 
-pub use iced_graphics::canvas::LineCap;
+pub use iced::widget::canvas::{Canvas, LineCap};
 
 use crate::style::{default_colors, text_marks, tick_marks};
 use crate::KnobAngleRange;

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -6,11 +6,11 @@ pub mod h_slider;
 pub mod knob;
 pub mod mod_range_input;
 pub mod ramp;
+pub mod text_marks;
+pub mod theme;
+pub mod tick_marks;
 pub mod v_slider;
 pub mod xy_pad;
-
-pub mod text_marks;
-pub mod tick_marks;
 
 //pub mod db_meter;
 //pub mod phase_meter;

--- a/src/style/mod_range_input.rs
+++ b/src/style/mod_range_input.rs
@@ -10,7 +10,7 @@ use crate::style::default_colors;
 ///
 /// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
 #[derive(Debug, Clone)]
-pub enum Style {
+pub enum Appearance {
     /// A circle style
     Circle(CircleStyle),
     /// A square style
@@ -23,9 +23,9 @@ pub enum Style {
     Invisible,
 }
 
-/// A circle [`Style`] for an [`ModRangeInput`]
+/// A circle [`Appearance`] for an [`ModRangeInput`]
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
 #[derive(Debug, Clone)]
 pub struct CircleStyle {
@@ -37,9 +37,19 @@ pub struct CircleStyle {
     pub border_color: Color,
 }
 
-/// A square [`Style`] for an [`ModRangeInput`]
+impl Default for CircleStyle {
+    fn default() -> Self {
+        CircleStyle {
+            color: default_colors::LIGHT_BACK,
+            border_width: 1.0,
+            border_color: default_colors::BORDER,
+        }
+    }
+}
+
+/// A square [`Appearance`] for an [`ModRangeInput`]
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
 #[derive(Debug, Clone)]
 pub struct SquareStyle {
@@ -57,84 +67,21 @@ pub struct SquareStyle {
 ///
 /// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
 pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
     /// Produces the style of an active [`ModRangeInput`].
     ///
     /// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
-    fn active(&self) -> Style;
+    fn active(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a hovered [`ModRangeInput`].
     ///
     /// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
-    fn hovered(&self) -> Style;
+    fn hovered(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a [`ModRangeInput`] that is being dragged.
     ///
     /// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
-    fn dragging(&self) -> Style;
-}
-
-struct Default;
-impl Default {
-    const ACTIVE_STYLE: CircleStyle = CircleStyle {
-        color: default_colors::LIGHT_BACK,
-        border_width: 1.0,
-        border_color: default_colors::BORDER,
-    };
-}
-impl StyleSheet for Default {
-    fn active(&self) -> Style {
-        Style::Circle(Self::ACTIVE_STYLE)
-    }
-
-    fn hovered(&self) -> Style {
-        Style::Circle(CircleStyle {
-            color: default_colors::KNOB_BACK_HOVER,
-            ..Self::ACTIVE_STYLE
-        })
-    }
-
-    fn dragging(&self) -> Style {
-        self.hovered()
-    }
-}
-
-/// An invisible [`StyleSheet`] for an [`ModRangeInput`]
-///
-/// Appearance is invisible, but the input is still interactable. Useful
-/// if placed right on top of a [`Knob`] with a [`ModRangeRingStyle`].
-///
-/// [`StyleSheet`]: struct.StyleSheet.html
-/// [`ModRangeInput`]: ../../native/mod_range_input/struct.ModRangeInput.html
-/// [`Knob`]: ../../native/knob/struct.Knob.html
-/// [`ModRangeRingStyle`]: ../knob/struct.ModRangeRingStyle.html
-#[allow(missing_debug_implementations)]
-pub struct DefaultInvisible;
-
-impl StyleSheet for DefaultInvisible {
-    fn active(&self) -> Style {
-        Style::Invisible
-    }
-
-    fn hovered(&self) -> Style {
-        self.active()
-    }
-
-    fn dragging(&self) -> Style {
-        self.active()
-    }
-}
-
-impl std::default::Default for Box<dyn StyleSheet> {
-    fn default() -> Self {
-        Box::new(Default)
-    }
-}
-
-impl<T> From<T> for Box<dyn StyleSheet>
-where
-    T: 'static + StyleSheet,
-{
-    fn from(style: T) -> Self {
-        Box::new(style)
-    }
+    fn dragging(&self, style: &Self::Style) -> Appearance;
 }

--- a/src/style/ramp.rs
+++ b/src/style/ramp.rs
@@ -10,7 +10,7 @@ use crate::style::default_colors;
 ///
 /// [`Ramp`]: ../../native/ramp/struct.Ramp.html
 #[derive(Debug, Clone)]
-pub struct Style {
+pub struct Appearance {
     /// The color of the background rectangle
     pub back_color: Color,
     /// The width of the border of the background rectangle
@@ -27,66 +27,39 @@ pub struct Style {
     pub line_down_color: Color,
 }
 
+impl Default for Appearance {
+    fn default() -> Self {
+        Appearance {
+            back_color: default_colors::LIGHT_BACK,
+            back_border_width: 1.0,
+            back_border_color: default_colors::BORDER,
+            line_width: 2.0,
+            line_center_color: default_colors::BORDER,
+            line_up_color: default_colors::BORDER,
+            line_down_color: default_colors::BORDER,
+        }
+    }
+}
+
 /// A set of rules that dictate the style of a [`Ramp`].
 ///
 /// [`Ramp`]: ../../native/ramp/struct.Ramp.html
 pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
     /// Produces the style of an active [`Ramp`].
     ///
     /// [`Ramp`]: ../../native/ramp/struct.Ramp.html
-    fn active(&self) -> Style;
+    fn active(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a hovered [`Ramp`].
     ///
     /// [`Ramp`]: ../../native/ramp/struct.Ramp.html
-    fn hovered(&self) -> Style;
+    fn hovered(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a [`Ramp`] that is being dragged.
     ///
     /// [`Ramp`]: ../../native/ramp/struct.Ramp.html
-    fn dragging(&self) -> Style;
-}
-
-struct Default;
-impl Default {
-    const ACTIVE_STYLE: Style = Style {
-        back_color: default_colors::LIGHT_BACK,
-        back_border_width: 1.0,
-        back_border_color: default_colors::BORDER,
-        line_width: 2.0,
-        line_center_color: default_colors::BORDER,
-        line_up_color: default_colors::BORDER,
-        line_down_color: default_colors::BORDER,
-    };
-}
-impl StyleSheet for Default {
-    fn active(&self) -> Style {
-        Self::ACTIVE_STYLE
-    }
-
-    fn hovered(&self) -> Style {
-        Style {
-            back_color: default_colors::RAMP_BACK_HOVER,
-            ..Self::ACTIVE_STYLE
-        }
-    }
-
-    fn dragging(&self) -> Style {
-        self.hovered()
-    }
-}
-
-impl std::default::Default for Box<dyn StyleSheet> {
-    fn default() -> Self {
-        Box::new(Default)
-    }
-}
-
-impl<T> From<T> for Box<dyn StyleSheet>
-where
-    T: 'static + StyleSheet,
-{
-    fn from(style: T) -> Self {
-        Box::new(style)
-    }
+    fn dragging(&self, style: &Self::Style) -> Appearance;
 }

--- a/src/style/text_marks.rs
+++ b/src/style/text_marks.rs
@@ -1,7 +1,7 @@
-//! Various styles for a [`TextMarkGroup`] in a bar meter widget
-///
-/// [`TextMarkGroup`]: ../../core/text_marks/struct.TextMarkGroup.html
-use iced_graphics::{Color, Font};
+//! Various styles for a [`text_marks::Group`] in a bar meter widget
+//!
+//! [`text_marks::Group`]: ../../native/text_marks/struct.Group.html
+use iced::{Color, Font};
 
 use crate::core::Offset;
 use crate::style::default_colors;

--- a/src/style/text_marks.rs
+++ b/src/style/text_marks.rs
@@ -101,7 +101,7 @@ impl std::cmp::PartialEq for Style {
     }
 }
 
-impl std::default::Default for Style {
+impl Default for Style {
     fn default() -> Self {
         Self {
             color: default_colors::TEXT_MARK,

--- a/src/style/theme.rs
+++ b/src/style/theme.rs
@@ -1,0 +1,549 @@
+//! Implement `iced_audio` styles for `iced`'s theme.
+
+use crate::core::{KnobAngleRange, Offset};
+use crate::style::{
+    default_colors, h_slider, knob, mod_range_input, ramp, text_marks,
+    tick_marks, v_slider, xy_pad,
+};
+
+/// The style of a HSlider.
+#[derive(Default)]
+pub enum HSlider {
+    /// The default style.
+    #[default]
+    Default,
+    /// A custom style.
+    Custom(Box<dyn h_slider::StyleSheet<Style = iced::Theme>>),
+}
+
+impl<S> From<S> for HSlider
+where
+    S: 'static + h_slider::StyleSheet<Style = iced::Theme>,
+{
+    fn from(val: S) -> Self {
+        HSlider::Custom(Box::new(val))
+    }
+}
+
+impl h_slider::StyleSheet for iced::Theme {
+    type Style = HSlider;
+
+    fn active(&self, style: &Self::Style) -> h_slider::Appearance {
+        match style {
+            HSlider::Default => {
+                h_slider::Appearance::Classic(Default::default())
+            }
+            HSlider::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn hovered(&self, style: &Self::Style) -> h_slider::Appearance {
+        match style {
+            HSlider::Default => {
+                h_slider::Appearance::Classic(h_slider::ClassicStyle {
+                    handle: h_slider::ClassicHandle {
+                        color: default_colors::LIGHT_BACK_HOVER,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            }
+            HSlider::Custom(custom) => custom.hovered(self),
+        }
+    }
+
+    fn dragging(&self, style: &Self::Style) -> h_slider::Appearance {
+        match style {
+            HSlider::Default => {
+                h_slider::Appearance::Classic(h_slider::ClassicStyle {
+                    handle: h_slider::ClassicHandle {
+                        color: default_colors::LIGHT_BACK_DRAG,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            }
+            HSlider::Custom(custom) => custom.dragging(self),
+        }
+    }
+
+    fn tick_marks_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<h_slider::TickMarksStyle> {
+        match style {
+            HSlider::Default => Some(h_slider::TickMarksStyle {
+                style: tick_marks::Style {
+                    tier_1: tick_marks::Shape::Line {
+                        length: 24.0,
+                        width: 2.0,
+                        color: default_colors::TICK_TIER_1,
+                    },
+                    tier_2: tick_marks::Shape::Line {
+                        length: 22.0,
+                        width: 1.0,
+                        color: default_colors::TICK_TIER_2,
+                    },
+                    tier_3: tick_marks::Shape::Line {
+                        length: 18.0,
+                        width: 1.0,
+                        color: default_colors::TICK_TIER_3,
+                    },
+                },
+                placement: tick_marks::Placement::Center {
+                    offset: Offset::ZERO,
+                    fill_length: false,
+                },
+            }),
+            HSlider::Custom(custom) => custom.tick_marks_style(self),
+        }
+    }
+
+    fn mod_range_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<h_slider::ModRangeStyle> {
+        match style {
+            HSlider::Default => None,
+            HSlider::Custom(custom) => custom.mod_range_style(self),
+        }
+    }
+
+    fn mod_range_style_2(
+        &self,
+        style: &Self::Style,
+    ) -> Option<h_slider::ModRangeStyle> {
+        match style {
+            HSlider::Default => None,
+            HSlider::Custom(custom) => custom.mod_range_style_2(self),
+        }
+    }
+
+    fn text_marks_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<h_slider::TextMarksStyle> {
+        match style {
+            HSlider::Default => Some(h_slider::TextMarksStyle {
+                style: Default::default(),
+                placement: text_marks::Placement::RightOrBottom {
+                    inside: false,
+                    offset: Offset { x: 0.0, y: 7.0 },
+                },
+            }),
+            HSlider::Custom(custom) => custom.text_marks_style(self),
+        }
+    }
+}
+
+/// The style of a Knob.
+#[derive(Default)]
+pub enum Knob {
+    /// The default style.
+    #[default]
+    Default,
+    /// A custom style.
+    Custom(Box<dyn knob::StyleSheet<Style = iced::Theme>>),
+}
+
+impl<S> From<S> for Knob
+where
+    S: 'static + knob::StyleSheet<Style = iced::Theme>,
+{
+    fn from(val: S) -> Self {
+        Knob::Custom(Box::new(val))
+    }
+}
+
+impl knob::StyleSheet for iced::Theme {
+    type Style = Knob;
+
+    fn active(&self, style: &Self::Style) -> knob::Appearance {
+        match style {
+            Knob::Default => knob::Appearance::Circle(Default::default()),
+            Knob::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn hovered(&self, style: &Self::Style) -> knob::Appearance {
+        match style {
+            Knob::Default => knob::Appearance::Circle(knob::CircleStyle {
+                color: default_colors::KNOB_BACK_HOVER,
+                ..Default::default()
+            }),
+            Knob::Custom(custom) => custom.hovered(self),
+        }
+    }
+
+    fn dragging(&self, style: &Self::Style) -> knob::Appearance {
+        match style {
+            Knob::Default => self.hovered(style),
+            Knob::Custom(custom) => custom.dragging(self),
+        }
+    }
+
+    fn angle_range(&self, style: &Self::Style) -> KnobAngleRange {
+        match style {
+            Knob::Default => KnobAngleRange::default(),
+            Knob::Custom(custom) => custom.angle_range(self),
+        }
+    }
+
+    fn tick_marks_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<knob::TickMarksStyle> {
+        match style {
+            Knob::Default => Some(knob::TickMarksStyle {
+                style: tick_marks::Style {
+                    tier_1: tick_marks::Shape::Circle {
+                        diameter: 4.0,
+                        color: default_colors::TICK_TIER_1,
+                    },
+                    tier_2: tick_marks::Shape::Circle {
+                        diameter: 2.0,
+                        color: default_colors::TICK_TIER_2,
+                    },
+                    tier_3: tick_marks::Shape::Circle {
+                        diameter: 2.0,
+                        color: default_colors::TICK_TIER_3,
+                    },
+                },
+                offset: 3.5,
+            }),
+            Knob::Custom(custom) => custom.tick_marks_style(self),
+        }
+    }
+
+    fn value_arc_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<knob::ValueArcStyle> {
+        match style {
+            Knob::Default => None,
+            Knob::Custom(custom) => custom.value_arc_style(self),
+        }
+    }
+
+    fn mod_range_arc_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<knob::ModRangeArcStyle> {
+        match style {
+            Knob::Default => None,
+            Knob::Custom(custom) => custom.mod_range_arc_style(self),
+        }
+    }
+
+    fn mod_range_arc_style_2(
+        &self,
+        style: &Self::Style,
+    ) -> Option<knob::ModRangeArcStyle> {
+        match style {
+            Knob::Default => None,
+            Knob::Custom(custom) => custom.mod_range_arc_style_2(self),
+        }
+    }
+
+    fn text_marks_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<knob::TextMarksStyle> {
+        match style {
+            Knob::Default => Some(knob::TextMarksStyle {
+                style: Default::default(),
+                offset: 14.0,
+                h_char_offset: 3.0,
+                v_offset: -0.75,
+            }),
+            Knob::Custom(custom) => custom.text_marks_style(self),
+        }
+    }
+}
+
+/// The style of a [`ModRangeInput`].
+#[derive(Default)]
+pub enum ModRangeInput {
+    /// The default style.
+    #[default]
+    Default,
+    /// The invisible style.
+    Invisible,
+    /// A custom style.
+    Custom(Box<dyn mod_range_input::StyleSheet<Style = iced::Theme>>),
+}
+
+impl<S> From<S> for ModRangeInput
+where
+    S: 'static + mod_range_input::StyleSheet<Style = iced::Theme>,
+{
+    fn from(val: S) -> Self {
+        ModRangeInput::Custom(Box::new(val))
+    }
+}
+
+impl mod_range_input::StyleSheet for iced::Theme {
+    type Style = ModRangeInput;
+
+    fn active(&self, style: &Self::Style) -> mod_range_input::Appearance {
+        match style {
+            ModRangeInput::Default => {
+                mod_range_input::Appearance::Circle(Default::default())
+            }
+            ModRangeInput::Invisible => mod_range_input::Appearance::Invisible,
+            ModRangeInput::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn hovered(&self, style: &Self::Style) -> mod_range_input::Appearance {
+        match style {
+            ModRangeInput::Default => mod_range_input::Appearance::Circle(
+                mod_range_input::CircleStyle {
+                    color: default_colors::KNOB_BACK_HOVER,
+                    ..Default::default()
+                },
+            ),
+            ModRangeInput::Invisible => self.active(style),
+            ModRangeInput::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn dragging(&self, style: &Self::Style) -> mod_range_input::Appearance {
+        match style {
+            ModRangeInput::Default => self.hovered(style),
+            ModRangeInput::Invisible => self.active(style),
+            ModRangeInput::Custom(custom) => custom.active(self),
+        }
+    }
+}
+
+/// The style of a Ramp.
+#[derive(Default)]
+pub enum Ramp {
+    /// The default style.
+    #[default]
+    Default,
+    /// A custom style.
+    Custom(Box<dyn ramp::StyleSheet<Style = iced::Theme>>),
+}
+
+impl<S> From<S> for Ramp
+where
+    S: 'static + ramp::StyleSheet<Style = iced::Theme>,
+{
+    fn from(val: S) -> Self {
+        Ramp::Custom(Box::new(val))
+    }
+}
+
+impl ramp::StyleSheet for iced::Theme {
+    type Style = Ramp;
+
+    fn active(&self, style: &Self::Style) -> ramp::Appearance {
+        match style {
+            Ramp::Default => Default::default(),
+            Ramp::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn hovered(&self, style: &Self::Style) -> ramp::Appearance {
+        match style {
+            Ramp::Default => ramp::Appearance {
+                back_color: default_colors::RAMP_BACK_HOVER,
+                ..Default::default()
+            },
+            Ramp::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn dragging(&self, style: &Self::Style) -> ramp::Appearance {
+        self.hovered(style)
+    }
+}
+
+/// The style of a VSlider.
+#[derive(Default)]
+pub enum VSlider {
+    /// The default style.
+    #[default]
+    Default,
+    /// A custom style.
+    Custom(Box<dyn v_slider::StyleSheet<Style = iced::Theme>>),
+}
+
+impl<S> From<S> for VSlider
+where
+    S: 'static + v_slider::StyleSheet<Style = iced::Theme>,
+{
+    fn from(val: S) -> Self {
+        VSlider::Custom(Box::new(val))
+    }
+}
+
+impl v_slider::StyleSheet for iced::Theme {
+    type Style = VSlider;
+
+    fn active(&self, style: &Self::Style) -> v_slider::Appearance {
+        match style {
+            VSlider::Default => {
+                v_slider::Appearance::Classic(Default::default())
+            }
+            VSlider::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn hovered(&self, style: &Self::Style) -> v_slider::Appearance {
+        match style {
+            VSlider::Default => {
+                v_slider::Appearance::Classic(v_slider::ClassicStyle {
+                    handle: v_slider::ClassicHandle {
+                        color: default_colors::LIGHT_BACK_HOVER,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            }
+            VSlider::Custom(custom) => custom.hovered(self),
+        }
+    }
+
+    fn dragging(&self, style: &Self::Style) -> v_slider::Appearance {
+        match style {
+            VSlider::Default => {
+                v_slider::Appearance::Classic(v_slider::ClassicStyle {
+                    handle: v_slider::ClassicHandle {
+                        color: default_colors::LIGHT_BACK_DRAG,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            }
+            VSlider::Custom(custom) => custom.dragging(self),
+        }
+    }
+
+    fn tick_marks_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<v_slider::TickMarksStyle> {
+        match style {
+            VSlider::Default => Some(v_slider::TickMarksStyle {
+                style: tick_marks::Style {
+                    tier_1: tick_marks::Shape::Line {
+                        length: 24.0,
+                        width: 2.0,
+                        color: default_colors::TICK_TIER_1,
+                    },
+                    tier_2: tick_marks::Shape::Line {
+                        length: 22.0,
+                        width: 1.0,
+                        color: default_colors::TICK_TIER_2,
+                    },
+                    tier_3: tick_marks::Shape::Line {
+                        length: 18.0,
+                        width: 1.0,
+                        color: default_colors::TICK_TIER_3,
+                    },
+                },
+                placement: tick_marks::Placement::Center {
+                    offset: Offset::ZERO,
+                    fill_length: false,
+                },
+            }),
+            VSlider::Custom(custom) => custom.tick_marks_style(self),
+        }
+    }
+
+    fn mod_range_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<v_slider::ModRangeStyle> {
+        match style {
+            VSlider::Default => None,
+            VSlider::Custom(custom) => custom.mod_range_style(self),
+        }
+    }
+
+    fn mod_range_style_2(
+        &self,
+        style: &Self::Style,
+    ) -> Option<v_slider::ModRangeStyle> {
+        match style {
+            VSlider::Default => None,
+            VSlider::Custom(custom) => custom.mod_range_style_2(self),
+        }
+    }
+
+    fn text_marks_style(
+        &self,
+        style: &Self::Style,
+    ) -> Option<v_slider::TextMarksStyle> {
+        match style {
+            VSlider::Default => Some(v_slider::TextMarksStyle {
+                style: Default::default(),
+                placement: text_marks::Placement::LeftOrTop {
+                    inside: false,
+                    offset: Offset { x: -7.0, y: 0.0 },
+                },
+            }),
+            VSlider::Custom(custom) => custom.text_marks_style(self),
+        }
+    }
+}
+
+/// The style of a XYPad.
+#[derive(Default)]
+pub enum XYPad {
+    /// The default style.
+    #[default]
+    Default,
+    /// A custom style.
+    Custom(Box<dyn xy_pad::StyleSheet<Style = iced::Theme>>),
+}
+
+impl<S> From<S> for XYPad
+where
+    S: 'static + xy_pad::StyleSheet<Style = iced::Theme>,
+{
+    fn from(val: S) -> Self {
+        XYPad::Custom(Box::new(val))
+    }
+}
+
+impl xy_pad::StyleSheet for iced::Theme {
+    type Style = XYPad;
+
+    fn active(&self, style: &Self::Style) -> xy_pad::Appearance {
+        match style {
+            XYPad::Default => Default::default(),
+            XYPad::Custom(custom) => custom.active(self),
+        }
+    }
+
+    fn hovered(&self, style: &Self::Style) -> xy_pad::Appearance {
+        match style {
+            XYPad::Default => xy_pad::Appearance {
+                handle: xy_pad::HandleShape::Circle(xy_pad::HandleCircle {
+                    color: default_colors::LIGHT_BACK_HOVER,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            XYPad::Custom(custom) => custom.hovered(self),
+        }
+    }
+
+    fn dragging(&self, style: &Self::Style) -> xy_pad::Appearance {
+        match style {
+            XYPad::Default => xy_pad::Appearance {
+                handle: xy_pad::HandleShape::Circle(xy_pad::HandleCircle {
+                    color: default_colors::LIGHT_BACK_DRAG,
+                    diameter: 9.0,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            XYPad::Custom(custom) => custom.dragging(self),
+        }
+    }
+}

--- a/src/style/tick_marks.rs
+++ b/src/style/tick_marks.rs
@@ -102,7 +102,7 @@ pub enum Shape {
     },
 }
 
-impl std::default::Default for Style {
+impl Default for Style {
     fn default() -> Self {
         Self {
             tier_1: Shape::Line {

--- a/src/style/tick_marks.rs
+++ b/src/style/tick_marks.rs
@@ -1,6 +1,6 @@
-//! Various styles for a [`TickMarkGroup`] in a bar meter widget
-///
-/// [`TickMarkGroup`]: ../../core/tick_marks/struct.TickMarkGroup.html
+//! Various styles for a [`tick_marks::Group`] in a bar meter widget
+//!
+//! [`tick_marks::Group`]: ../../native/tick_marks/struct.Group.html
 use iced_native::Color;
 
 use crate::core::Offset;

--- a/src/style/v_slider.rs
+++ b/src/style/v_slider.rs
@@ -4,14 +4,13 @@
 
 use iced_native::{image, Color, Rectangle};
 
-use crate::core::Offset;
 use crate::style::{default_colors, text_marks, tick_marks};
 
 /// The appearance of a [`VSlider`].
 ///
 /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
 #[derive(Debug, Clone)]
-pub enum Style {
+pub enum Appearance {
     /// uses an image texture for the handle
     Texture(TextureStyle),
     /// modeled after hardware sliders
@@ -34,9 +33,9 @@ pub struct ClassicRail {
     pub rail_padding: f32,
 }
 
-/// A [`Style`] for a [`VSlider`] that uses an image texture for the handle
+/// A [`Appearance`] for a [`VSlider`] that uses an image texture for the handle
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
 /// [`Handle`]: https://docs.rs/iced/latest/iced/pure/widget/image/struct.Handle.html
 #[derive(Debug, Clone)]
@@ -54,9 +53,9 @@ pub struct TextureStyle {
     pub image_bounds: Rectangle,
 }
 
-/// A classic [`Style`] for a [`VSlider`], modeled after hardware sliders
+/// A classic [`Appearance`] for a [`VSlider`], modeled after hardware sliders
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
 /// [`ClassicHandle`]: struct.ClassicHandle.html
 #[derive(Debug, Clone)]
@@ -65,6 +64,19 @@ pub struct ClassicStyle {
     pub rail: ClassicRail,
     /// a `ClassicHandle` defining the style of the handle
     pub handle: ClassicHandle,
+}
+
+impl Default for ClassicStyle {
+    fn default() -> Self {
+        ClassicStyle {
+            rail: ClassicRail {
+                rail_colors: default_colors::SLIDER_RAIL,
+                rail_widths: (1.0, 1.0),
+                rail_padding: 12.0,
+            },
+            handle: ClassicHandle::default(),
+        }
+    }
 }
 
 /// The [`ClassicStyle`] appearance of the handle of a [`VSlider`]
@@ -89,10 +101,24 @@ pub struct ClassicHandle {
     pub border_color: Color,
 }
 
-/// A modern [`Style`] for a [`VSlider`]. It is composed of a background
+impl Default for ClassicHandle {
+    fn default() -> Self {
+        ClassicHandle {
+            color: default_colors::LIGHT_BACK,
+            height: 34,
+            notch_width: 4.0,
+            notch_color: default_colors::BORDER,
+            border_radius: 2.0,
+            border_color: default_colors::BORDER,
+            border_width: 1.0,
+        }
+    }
+}
+
+/// A modern [`Appearance`] for a [`VSlider`]. It is composed of a background
 /// rectangle and a rectangular handle.
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
 #[derive(Debug, Clone, Copy)]
 pub struct RectStyle {
@@ -115,11 +141,11 @@ pub struct RectStyle {
     pub handle_filled_gap: f32,
 }
 
-/// A modern [`Style`] for a [`VSlider`]. It is composed of a background
+/// A modern [`Appearance`] for a [`VSlider`]. It is composed of a background
 /// rectangle and a rectangular handle. It has different colors for left, right,
 /// and center values.
 ///
-/// [`Style`]: enum.Style.html
+/// [`Appearance`]: enum.Appearance.html
 /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
 #[derive(Debug, Clone, Copy)]
 pub struct RectBipolarStyle {
@@ -237,27 +263,30 @@ pub struct TextMarksStyle {
 ///
 /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
 pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
     /// Produces the style of an active [`VSlider`].
     ///
     /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-    fn active(&self) -> Style;
+    fn active(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a hovered [`VSlider`].
     ///
     /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-    fn hovered(&self) -> Style;
+    fn hovered(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a [`VSlider`] that is being dragged.
     ///
     /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-    fn dragging(&self) -> Style;
+    fn dragging(&self, style: &Self::Style) -> Appearance;
 
     /// The style of tick marks for a [`VSlider`]
     ///
     /// For no tick marks, don't override this or set this to return `None`.
     ///
     /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-    fn tick_marks_style(&self) -> Option<TickMarksStyle> {
+    fn tick_marks_style(&self, _style: &Self::Style) -> Option<TickMarksStyle> {
         None
     }
 
@@ -267,7 +296,7 @@ pub trait StyleSheet {
     ///
     /// [`ModulationRange`]: ../../core/struct.ModulationRange.html
     /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-    fn mod_range_style(&self) -> Option<ModRangeStyle> {
+    fn mod_range_style(&self, _style: &Self::Style) -> Option<ModRangeStyle> {
         None
     }
 
@@ -277,7 +306,7 @@ pub trait StyleSheet {
     ///
     /// [`ModulationRange`]: ../../core/struct.ModulationRange.html
     /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-    fn mod_range_style_2(&self) -> Option<ModRangeStyle> {
+    fn mod_range_style_2(&self, _style: &Self::Style) -> Option<ModRangeStyle> {
         None
     }
 
@@ -286,103 +315,7 @@ pub trait StyleSheet {
     /// For no text marks, don't override this or set this to return `None`.
     ///
     /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-    fn text_marks_style(&self) -> Option<TextMarksStyle> {
+    fn text_marks_style(&self, _style: &Self::Style) -> Option<TextMarksStyle> {
         None
-    }
-}
-
-struct Default;
-impl Default {
-    const ACTIVE_STYLE: ClassicStyle = ClassicStyle {
-        rail: ClassicRail {
-            rail_colors: default_colors::SLIDER_RAIL,
-            rail_widths: (1.0, 1.0),
-            rail_padding: 12.0,
-        },
-        handle: ClassicHandle {
-            color: default_colors::LIGHT_BACK,
-            height: 34,
-            notch_width: 4.0,
-            notch_color: default_colors::BORDER,
-            border_radius: 2.0,
-            border_color: default_colors::BORDER,
-            border_width: 1.0,
-        },
-    };
-}
-impl StyleSheet for Default {
-    fn active(&self) -> Style {
-        Style::Classic(Self::ACTIVE_STYLE)
-    }
-
-    fn hovered(&self) -> Style {
-        Style::Classic(ClassicStyle {
-            handle: ClassicHandle {
-                color: default_colors::LIGHT_BACK_HOVER,
-                ..Self::ACTIVE_STYLE.handle
-            },
-            ..Self::ACTIVE_STYLE
-        })
-    }
-
-    fn dragging(&self) -> Style {
-        Style::Classic(ClassicStyle {
-            handle: ClassicHandle {
-                color: default_colors::LIGHT_BACK_DRAG,
-                ..Self::ACTIVE_STYLE.handle
-            },
-            ..Self::ACTIVE_STYLE
-        })
-    }
-
-    fn tick_marks_style(&self) -> Option<TickMarksStyle> {
-        Some(TickMarksStyle {
-            style: tick_marks::Style {
-                tier_1: tick_marks::Shape::Line {
-                    length: 24.0,
-                    width: 2.0,
-                    color: default_colors::TICK_TIER_1,
-                },
-                tier_2: tick_marks::Shape::Line {
-                    length: 22.0,
-                    width: 1.0,
-                    color: default_colors::TICK_TIER_2,
-                },
-                tier_3: tick_marks::Shape::Line {
-                    length: 18.0,
-                    width: 1.0,
-                    color: default_colors::TICK_TIER_3,
-                },
-            },
-            placement: tick_marks::Placement::Center {
-                offset: Offset::ZERO,
-                fill_length: false,
-            },
-        })
-    }
-
-    fn text_marks_style(&self) -> Option<TextMarksStyle> {
-        Some(TextMarksStyle {
-            style: text_marks::Style::default(),
-            placement: text_marks::Placement::LeftOrTop {
-                inside: false,
-                offset: Offset { x: -7.0, y: 0.0 },
-            },
-        })
-    }
-}
-
-impl std::default::Default for Box<dyn StyleSheet> {
-    fn default() -> Self {
-        Box::new(Default)
-    }
-}
-
-impl<T> From<T> for Box<dyn StyleSheet>
-where
-    T: 'static + StyleSheet,
-{
-    fn from(style: T) -> Self {
-        Box::new(style)
     }
 }

--- a/src/style/v_slider.rs
+++ b/src/style/v_slider.rs
@@ -38,12 +38,14 @@ pub struct ClassicRail {
 ///
 /// [`Style`]: enum.Style.html
 /// [`VSlider`]: ../../native/v_slider/struct.VSlider.html
-/// [`Handle`]: https://docs.rs/iced/0.1.1/iced/widget/image/struct.Handle.html
+/// [`Handle`]: https://docs.rs/iced/latest/iced/pure/widget/image/struct.Handle.html
 #[derive(Debug, Clone)]
 pub struct TextureStyle {
     /// The rail style
     pub rail: ClassicRail,
     /// The [`Handle`] to the image texture
+    ///
+    /// [`Handle`]: https://docs.rs/iced/latest/iced/pure/widget/image/struct.Handle.html
     pub image_handle: image::Handle,
     /// The effective height of the handle (not including any padding on the texture)
     pub handle_height: u16,

--- a/src/style/xy_pad.rs
+++ b/src/style/xy_pad.rs
@@ -11,7 +11,7 @@ use crate::style::default_colors;
 /// [`XYPad`]: ../../native/xy_pad/struct.XYPad.html
 /// [`HandleShape`]: enum.HandleShape.html
 #[derive(Debug, Clone)]
-pub struct Style {
+pub struct Appearance {
     /// the width of the horizontal and vertical rail lines
     pub rail_width: f32,
     /// color of the horizontal rail line
@@ -32,6 +32,22 @@ pub struct Style {
     pub center_line_width: f32,
     /// the color of the center line markings
     pub center_line_color: Color,
+}
+
+impl Default for Appearance {
+    fn default() -> Self {
+        Appearance {
+            rail_width: 2.0,
+            h_rail_color: default_colors::XY_PAD_RAIL,
+            v_rail_color: default_colors::XY_PAD_RAIL,
+            handle: HandleShape::Circle(Default::default()),
+            back_color: default_colors::LIGHT_BACK,
+            border_width: 1.0,
+            border_color: default_colors::BORDER,
+            center_line_width: 1.0,
+            center_line_color: default_colors::XY_PAD_CENTER_LINE,
+        }
+    }
 }
 
 /// The shape of the handle for the [`Style`] of an [`XYPad`]
@@ -62,6 +78,17 @@ pub struct HandleCircle {
     pub border_color: Color,
 }
 
+impl Default for HandleCircle {
+    fn default() -> Self {
+        HandleCircle {
+            color: default_colors::LIGHT_BACK,
+            diameter: 11.0,
+            border_width: 2.0,
+            border_color: default_colors::BORDER,
+        }
+    }
+}
+
 /// a square handle style for the [`Style`] of an [`XYPad`]
 ///
 /// [`XYPad`]: ../../native/xy_pad/struct.XYPad.html
@@ -84,80 +111,21 @@ pub struct HandleSquare {
 ///
 /// [`XYPad`]: ../../native/xy_pad/struct.XYPad.html
 pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
     /// Produces the style of an active [`XYPad`].
     ///
     /// [`XYPad`]: ../../native/xy_pad/struct.XYPad.html
-    fn active(&self) -> Style;
+    fn active(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of a hovered [`XYPad`].
     ///
     /// [`XYPad`]: ../../native/xy_pad/struct.XYPad.html
-    fn hovered(&self) -> Style;
+    fn hovered(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the style of an [`XYPad`] that is being dragged.
     ///
     /// [`XYPad`]: ../../native/xy_pad/struct.XYPad.html
-    fn dragging(&self) -> Style;
-}
-
-struct Default;
-impl Default {
-    const ACTIVE_HANDLE: HandleCircle = HandleCircle {
-        color: default_colors::LIGHT_BACK,
-        diameter: 11.0,
-        border_width: 2.0,
-        border_color: default_colors::BORDER,
-    };
-    const ACTIVE_STYLE: Style = Style {
-        rail_width: 2.0,
-        h_rail_color: default_colors::XY_PAD_RAIL,
-        v_rail_color: default_colors::XY_PAD_RAIL,
-        handle: HandleShape::Circle(Self::ACTIVE_HANDLE),
-        back_color: default_colors::LIGHT_BACK,
-        border_width: 1.0,
-        border_color: default_colors::BORDER,
-        center_line_width: 1.0,
-        center_line_color: default_colors::XY_PAD_CENTER_LINE,
-    };
-}
-impl StyleSheet for Default {
-    fn active(&self) -> Style {
-        Self::ACTIVE_STYLE
-    }
-
-    fn hovered(&self) -> Style {
-        Style {
-            handle: HandleShape::Circle(HandleCircle {
-                color: default_colors::LIGHT_BACK_HOVER,
-                ..Self::ACTIVE_HANDLE
-            }),
-            ..Self::ACTIVE_STYLE
-        }
-    }
-
-    fn dragging(&self) -> Style {
-        Style {
-            handle: HandleShape::Circle(HandleCircle {
-                color: default_colors::LIGHT_BACK_DRAG,
-                diameter: 9.0,
-                ..Self::ACTIVE_HANDLE
-            }),
-            ..Self::ACTIVE_STYLE
-        }
-    }
-}
-
-impl std::default::Default for Box<dyn StyleSheet> {
-    fn default() -> Self {
-        Box::new(Default)
-    }
-}
-
-impl<T> From<T> for Box<dyn StyleSheet>
-where
-    T: 'static + StyleSheet,
-{
-    fn from(style: T) -> Self {
-        Box::new(style)
-    }
+    fn dragging(&self, style: &Self::Style) -> Appearance;
 }


### PR DESCRIPTION
This is a proposal for a migration to iced's "pure" widget design. See https://docs.rs/iced/latest/iced/pure/index.html.
It targets iced current main branch.

The second commit suggests slight improvements, which are independent of the migration.

Fixes https://github.com/iced-rs/iced_audio/issues/23