### PR TITLE
Fix value discontinuity resulting from an external change

### DIFF
--- a/src/graphics/h_slider.rs
+++ b/src/graphics/h_slider.rs
@@ -123,10 +123,10 @@ where
     }
 }
 
-fn draw_value_markers<'a>(
+fn draw_value_markers(
     mark_bounds: &Rectangle,
     mod_bounds: &Rectangle,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> (Primitive, Primitive, Primitive, Primitive) {
@@ -295,11 +295,11 @@ fn draw_mod_range(
     }
 }
 
-fn draw_texture_style<'a>(
+fn draw_texture_style(
     normal: Normal,
     bounds: &Rectangle,
     style: TextureAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -346,11 +346,11 @@ fn draw_texture_style<'a>(
     }
 }
 
-fn draw_classic_style<'a>(
+fn draw_classic_style(
     normal: Normal,
     bounds: &Rectangle,
     style: &ClassicAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -423,11 +423,11 @@ fn draw_classic_style<'a>(
     }
 }
 
-fn draw_rect_style<'a>(
+fn draw_rect_style(
     normal: Normal,
     bounds: &Rectangle,
     style: &RectAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -507,11 +507,11 @@ fn draw_rect_style<'a>(
     }
 }
 
-fn draw_rect_bipolar_style<'a>(
+fn draw_rect_bipolar_style(
     normal: Normal,
     bounds: &Rectangle,
     style: &RectBipolarAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {

--- a/src/graphics/knob.rs
+++ b/src/graphics/knob.rs
@@ -168,9 +168,9 @@ where
     }
 }
 
-fn draw_value_markers<'a>(
+fn draw_value_markers(
     knob_info: &KnobInfo,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> (Primitive, Primitive, Primitive, Primitive, Primitive) {
@@ -537,10 +537,10 @@ fn draw_notch(knob_info: &KnobInfo, notch: &NotchShape) -> Primitive {
     }
 }
 
-fn draw_circle_style<'a>(
+fn draw_circle_style(
     knob_info: &KnobInfo,
     style: CircleAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -575,10 +575,10 @@ fn draw_circle_style<'a>(
     }
 }
 
-fn draw_arc_style<'a>(
+fn draw_arc_style(
     knob_info: &KnobInfo,
     style: ArcAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -683,10 +683,10 @@ impl BipolarState {
     }
 }
 
-fn draw_arc_bipolar_style<'a>(
+fn draw_arc_bipolar_style(
     knob_info: &KnobInfo,
     style: ArcBipolarAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {

--- a/src/graphics/ramp.rs
+++ b/src/graphics/ramp.rs
@@ -65,7 +65,7 @@ where
             border_color: appearance.back_border_color,
         };
 
-        let border_width = appearance.back_border_width as f32;
+        let border_width = appearance.back_border_width;
         let twice_border_width = border_width * 2.0;
 
         let range_width = bounds_width - twice_border_width;
@@ -75,7 +75,7 @@ where
             RampDirection::Up => {
                 if normal.as_f32() < 0.449 {
                     let stroke = Stroke {
-                        width: appearance.line_width as f32,
+                        width: appearance.line_width,
                         style: canvas::Style::Solid(appearance.line_down_color),
                         line_cap: LineCap::Square,
                         ..Stroke::default()
@@ -107,7 +107,7 @@ where
                     }
                 } else if normal.as_f32() > 0.501 {
                     let stroke = Stroke {
-                        width: appearance.line_width as f32,
+                        width: appearance.line_width,
                         style: canvas::Style::Solid(appearance.line_up_color),
                         line_cap: LineCap::Square,
                         ..Stroke::default()
@@ -142,7 +142,7 @@ where
                     }
                 } else {
                     let stroke = Stroke {
-                        width: appearance.line_width as f32,
+                        width: appearance.line_width,
                         style: canvas::Style::Solid(
                             appearance.line_center_color,
                         ),
@@ -176,7 +176,7 @@ where
             RampDirection::Down => {
                 if normal.as_f32() < 0.449 {
                     let stroke = Stroke {
-                        width: appearance.line_width as f32,
+                        width: appearance.line_width,
                         style: canvas::Style::Solid(appearance.line_down_color),
                         line_cap: LineCap::Square,
                         ..Stroke::default()
@@ -210,7 +210,7 @@ where
                     }
                 } else if normal.as_f32() > 0.501 {
                     let stroke = Stroke {
-                        width: appearance.line_width as f32,
+                        width: appearance.line_width,
                         style: canvas::Style::Solid(appearance.line_up_color),
                         line_cap: LineCap::Square,
                         ..Stroke::default()
@@ -246,7 +246,7 @@ where
                     }
                 } else {
                     let stroke = Stroke {
-                        width: appearance.line_width as f32,
+                        width: appearance.line_width,
                         style: canvas::Style::Solid(
                             appearance.line_center_color,
                         ),

--- a/src/graphics/v_slider.rs
+++ b/src/graphics/v_slider.rs
@@ -123,10 +123,10 @@ where
     }
 }
 
-fn draw_value_markers<'a>(
+fn draw_value_markers(
     mark_bounds: &Rectangle,
     mod_bounds: &Rectangle,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> (Primitive, Primitive, Primitive, Primitive) {
@@ -294,11 +294,11 @@ fn draw_mod_range(
     }
 }
 
-fn draw_texture_style<'a>(
+fn draw_texture_style(
     normal: Normal,
     bounds: &Rectangle,
     style: TextureAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -345,11 +345,11 @@ fn draw_texture_style<'a>(
     }
 }
 
-fn draw_classic_style<'a>(
+fn draw_classic_style(
     normal: Normal,
     bounds: &Rectangle,
     style: &ClassicAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -422,11 +422,11 @@ fn draw_classic_style<'a>(
     }
 }
 
-fn draw_rect_style<'a>(
+fn draw_rect_style(
     normal: Normal,
     bounds: &Rectangle,
     style: &RectAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {
@@ -507,11 +507,11 @@ fn draw_rect_style<'a>(
     }
 }
 
-fn draw_rect_bipolar_style<'a>(
+fn draw_rect_bipolar_style(
     normal: Normal,
     bounds: &Rectangle,
     style: &RectBipolarAppearance,
-    value_markers: &ValueMarkers<'a>,
+    value_markers: &ValueMarkers<'_>,
     tick_marks_cache: &tick_marks::PrimitiveCache,
     text_marks_cache: &text_marks::PrimitiveCache,
 ) -> Primitive {

--- a/src/graphics/xy_pad.rs
+++ b/src/graphics/xy_pad.rs
@@ -82,7 +82,7 @@ where
         let (h_center_line, v_center_line) = if appearance.center_line_color
             != Color::TRANSPARENT
         {
-            let center_line_width = appearance.center_line_width as f32;
+            let center_line_width = appearance.center_line_width;
             let half_center_line_width = (center_line_width / 2.0).floor();
 
             (
@@ -116,7 +116,7 @@ where
         };
 
         let (h_rail, v_rail) = if appearance.rail_width != 0.0 {
-            let rail_width = appearance.rail_width as f32;
+            let rail_width = appearance.rail_width;
             let half_rail_width = (rail_width / 2.0).floor();
             (
                 Primitive::Quad {
@@ -124,7 +124,7 @@ where
                         x: bounds_x,
                         y: handle_y - half_rail_width,
                         width: bounds_size,
-                        height: appearance.rail_width as f32,
+                        height: appearance.rail_width,
                     },
                     background: Background::Color(appearance.h_rail_color),
                     border_radius: [0.0; 4],
@@ -135,7 +135,7 @@ where
                     bounds: Rectangle {
                         x: handle_x - half_rail_width,
                         y: bounds_y,
-                        width: appearance.rail_width as f32,
+                        width: appearance.rail_width,
                         height: bounds_size,
                     },
                     background: Background::Color(appearance.v_rail_color),
@@ -151,7 +151,7 @@ where
         let handle = {
             match appearance.handle {
                 HandleShape::Circle(circle) => {
-                    let diameter = circle.diameter as f32;
+                    let diameter = circle.diameter;
                     let radius = diameter / 2.0;
 
                     Primitive::Quad {

--- a/src/native/h_slider.rs
+++ b/src/native/h_slider.rs
@@ -285,6 +285,7 @@ where
 struct State {
     dragging_status: Option<SliderStatus>,
     prev_drag_x: f32,
+    prev_normal: Normal,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
     last_click: Option<mouse::Click>,
@@ -304,6 +305,7 @@ impl State {
         Self {
             dragging_status: None,
             prev_drag_x: 0.0,
+            prev_normal: normal,
             continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
@@ -358,6 +360,14 @@ where
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let state = state.state.downcast_mut::<State>();
+
+        // Update state after a discontinuity
+        if state.dragging_status.is_none()
+            && state.prev_normal != self.normal_param.value
+        {
+            state.prev_normal = self.normal_param.value;
+            state.continuous_normal = self.normal_param.value.as_f32();
+        }
 
         match event {
             Event::Mouse(mouse::Event::CursorMoved { .. })
@@ -455,8 +465,6 @@ where
 
                             state.dragging_status = Some(Default::default());
                             state.prev_drag_x = cursor_position.x;
-                            state.continuous_normal =
-                                self.normal_param.value.as_f32();
                         }
                         _ => {
                             // Reset to default
@@ -473,8 +481,6 @@ where
 
                                 self.normal_param.value =
                                     self.normal_param.default;
-                                state.continuous_normal =
-                                    self.normal_param.default.as_f32();
 
                                 self.fire_on_change(shell);
 
@@ -499,8 +505,6 @@ where
                         // so as to terminate the action, regardless of the actual user movement.
                         self.maybe_fire_on_release(shell);
                     }
-
-                    state.continuous_normal = self.normal_param.value.as_f32();
 
                     return event::Status::Captured;
                 }

--- a/src/native/knob.rs
+++ b/src/native/knob.rs
@@ -282,6 +282,7 @@ where
 struct State {
     dragging_status: Option<SliderStatus>,
     prev_drag_y: f32,
+    prev_normal: Normal,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
     last_click: Option<mouse::Click>,
@@ -301,6 +302,7 @@ impl State {
         Self {
             dragging_status: None,
             prev_drag_y: 0.0,
+            prev_normal: normal,
             continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
@@ -355,6 +357,14 @@ where
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let state = state.state.downcast_mut::<State>();
+
+        // Update state after a discontinuity
+        if state.dragging_status.is_none()
+            && state.prev_normal != self.normal_param.value
+        {
+            state.prev_normal = self.normal_param.value;
+            state.continuous_normal = self.normal_param.value.as_f32();
+        }
 
         match event {
             Event::Mouse(mouse::Event::CursorMoved { .. })
@@ -441,8 +451,6 @@ where
 
                             state.dragging_status = Some(Default::default());
                             state.prev_drag_y = cursor_position.y;
-                            state.continuous_normal =
-                                self.normal_param.value.as_f32();
                         }
                         _ => {
                             // Reset to default
@@ -459,8 +467,6 @@ where
 
                                 self.normal_param.value =
                                     self.normal_param.default;
-                                state.continuous_normal =
-                                    self.normal_param.default.as_f32();
 
                                 self.fire_on_change(shell);
 
@@ -485,8 +491,6 @@ where
                         // so as to terminate the action, regardless of the actual user movement.
                         self.maybe_fire_on_release(shell);
                     }
-
-                    state.continuous_normal = self.normal_param.value.as_f32();
 
                     return event::Status::Captured;
                 }

--- a/src/native/mod_range_input.rs
+++ b/src/native/mod_range_input.rs
@@ -220,6 +220,7 @@ where
 struct State {
     dragging_status: Option<SliderStatus>,
     prev_drag_y: f32,
+    prev_normal: Normal,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
     last_click: Option<mouse::Click>,
@@ -237,6 +238,7 @@ impl State {
         Self {
             dragging_status: None,
             prev_drag_y: 0.0,
+            prev_normal: normal,
             continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
@@ -289,6 +291,14 @@ where
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let state = state.state.downcast_mut::<State>();
+
+        // Update state after a discontinuity
+        if state.dragging_status.is_none()
+            && state.prev_normal != self.normal_param.value
+        {
+            state.prev_normal = self.normal_param.value;
+            state.continuous_normal = self.normal_param.value.as_f32();
+        }
 
         match event {
             Event::Mouse(mouse::Event::CursorMoved { .. })
@@ -375,8 +385,6 @@ where
 
                             state.dragging_status = Some(Default::default());
                             state.prev_drag_y = cursor_position.y;
-                            state.continuous_normal =
-                                self.normal_param.value.as_f32();
                         }
                         _ => {
                             // Reset to default
@@ -393,8 +401,6 @@ where
 
                                 self.normal_param.value =
                                     self.normal_param.default;
-                                state.continuous_normal =
-                                    self.normal_param.default.as_f32();
 
                                 self.fire_on_change(shell);
 
@@ -419,8 +425,6 @@ where
                         // so as to terminate the action, regardless of the actual user movement.
                         self.maybe_fire_on_release(shell);
                     }
-
-                    state.continuous_normal = self.normal_param.value.as_f32();
 
                     return event::Status::Captured;
                 }

--- a/src/native/ramp.rs
+++ b/src/native/ramp.rs
@@ -260,6 +260,7 @@ where
 struct State {
     dragging_status: Option<SliderStatus>,
     prev_drag_y: f32,
+    prev_normal: Normal,
     continuous_normal: f32,
     pressed_modifiers: keyboard::Modifiers,
     last_click: Option<mouse::Click>,
@@ -280,6 +281,7 @@ impl State {
         Self {
             dragging_status: None,
             prev_drag_y: 0.0,
+            prev_normal: normal,
             continuous_normal: normal.as_f32(),
             pressed_modifiers: Default::default(),
             last_click: None,
@@ -332,6 +334,14 @@ where
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let state = state.state.downcast_mut::<State>();
+
+        // Update state after a discontinuity
+        if state.dragging_status.is_none()
+            && state.prev_normal != self.normal_param.value
+        {
+            state.prev_normal = self.normal_param.value;
+            state.continuous_normal = self.normal_param.value.as_f32();
+        }
 
         match event {
             Event::Mouse(mouse::Event::CursorMoved { .. })
@@ -418,8 +428,6 @@ where
 
                             state.dragging_status = Some(Default::default());
                             state.prev_drag_y = cursor_position.y;
-                            state.continuous_normal =
-                                self.normal_param.value.as_f32();
                         }
                         _ => {
                             // Reset to default
@@ -436,8 +444,6 @@ where
 
                                 self.normal_param.value =
                                     self.normal_param.default;
-                                state.continuous_normal =
-                                    self.normal_param.default.as_f32();
 
                                 self.fire_on_change(shell);
 
@@ -462,8 +468,6 @@ where
                         // so as to terminate the action, regardless of the actual user movement.
                         self.maybe_fire_on_release(shell);
                     }
-
-                    state.continuous_normal = self.normal_param.value.as_f32();
 
                     return event::Status::Captured;
                 }


### PR DESCRIPTION
When a value discontinuity occurred as a result of an external change (as opposed to a change resulting from a user interaction with the widget), a subsequent wheel scroll would start from the value prior to the discontinuity. This was due to the `continous_normal` not being synchronized at discontinuity.

This didn't occur when dragging the widget because the `continuous_normal` is synchronized when the mouse button is pressed.

This commit solves the issue by keeping previous normal value and by synchronizing `continuous_normal` when an elligible discontinuity is detected. Synchronization is also factorized instead of being scattered at the various use cases sites.

All widgets are updated except `XYPad`, which doesn't use the wheel scroll event. This widget could have been updated by factorizing the `continuous_normal` synchronization, but that would add the `prev_normal` field to the `State`, which is not needed. I decided not to add the extra field and keep current implementation untouched.